### PR TITLE
Add unit_cast, to_linear, and to_angular functions

### DIFF
--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -111,10 +111,7 @@ template <typename Q>
 concept isQuantity = requires(Q q) { quantityChecker(q); };
 
 // Un(type)safely coerce the a unit into a different unit
-template<isQuantity Q1, isQuantity Q2>
-constexpr inline Q1 unit_cast(Q2 quantity) {
-    return Q1(quantity.val());
-}
+template <isQuantity Q1, isQuantity Q2> constexpr inline Q1 unit_cast(Q2 quantity) { return Q1(quantity.val()); }
 
 template <isQuantity Q1, isQuantity Q2> using QMultiplication = Quantity<
     std::ratio_add<typename Q1::mass, typename Q2::mass>, std::ratio_add<typename Q1::length, typename Q2::length>,
@@ -319,43 +316,21 @@ template <isQuantity Q> constexpr Q round(const Q& lhs, const Q& rhs) {
 // Convert an angular unit `Q` to a linear unit correctly;
 // mostly useful for velocities
 template <isQuantity Q>
-Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
-toLinear(
-    Quantity<
-    typename Q::mass, 
-    typename Q::length, 
-    typename Q::time, 
-    typename Q::current,
-    typename Q::angle> angular, 
+Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length> toLinear(
+    Quantity<typename Q::mass, typename Q::length, typename Q::time, typename Q::current, typename Q::angle> angular,
     Length diameter) {
     return unit_cast<
-        Quantity<
-        typename Q::mass, 
-        typename Q::angle, 
-        typename Q::time, 
-        typename Q::current, 
-        typename Q::length>
-    >(angular * (diameter / 2.0));
+        Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>>(
+        angular * (diameter / 2.0));
 }
 
 // Convert an linear unit `Q` to a angular unit correctly;
 // mostly useful for velocities
 template <isQuantity Q>
-Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
-toAngular(
-    Quantity<
-    typename Q::mass, 
-    typename Q::length, 
-    typename Q::time, 
-    typename Q::current,
-    typename Q::angle> linear, 
+Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length> toAngular(
+    Quantity<typename Q::mass, typename Q::length, typename Q::time, typename Q::current, typename Q::angle> linear,
     Length diameter) {
     return unit_cast<
-        Quantity<
-        typename Q::mass, 
-        typename Q::angle, 
-        typename Q::time, 
-        typename Q::current, 
-        typename Q::length>
-    >(linear / (diameter / 2.0));
+        Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>>(
+        linear / (diameter / 2.0));
 }

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -320,7 +320,7 @@ template <isQuantity Q> constexpr Q round(const Q& lhs, const Q& rhs) {
 // mostly useful for velocities
 template <isQuantity Q>
 Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
-to_linear(
+toLinear(
     Quantity<
     typename Q::mass, 
     typename Q::length, 
@@ -342,7 +342,7 @@ to_linear(
 // mostly useful for velocities
 template <isQuantity Q>
 Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
-to_angular(
+toAngular(
     Quantity<
     typename Q::mass, 
     typename Q::length, 

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -110,6 +110,11 @@ template <TYPENAMES> void quantityChecker(Quantity<DIMS> q) {}
 template <typename Q>
 concept isQuantity = requires(Q q) { quantityChecker(q); };
 
+template<isQuantity Q1, isQuantity Q2>
+constexpr inline Q1 unit_cast(Q2 quantity) {
+    return Q1(quantity.val());
+}
+
 template <isQuantity Q1, isQuantity Q2> using QMultiplication = Quantity<
     std::ratio_add<typename Q1::mass, typename Q2::mass>, std::ratio_add<typename Q1::length, typename Q2::length>,
     std::ratio_add<typename Q1::time, typename Q2::time>, std::ratio_add<typename Q1::current, typename Q2::current>,

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -110,6 +110,7 @@ template <TYPENAMES> void quantityChecker(Quantity<DIMS> q) {}
 template <typename Q>
 concept isQuantity = requires(Q q) { quantityChecker(q); };
 
+// Un(type)safely coerce the a unit into a different unit
 template<isQuantity Q1, isQuantity Q2>
 constexpr inline Q1 unit_cast(Q2 quantity) {
     return Q1(quantity.val());
@@ -314,3 +315,47 @@ template <isQuantity Q> constexpr Q round(const Q& lhs, const Q& rhs) {
     return Q(std::round(lhs.val() / rhs.val()) * rhs.val());
 }
 } // namespace units
+
+// Convert an angular unit `Q` to a linear unit correctly;
+// mostly useful for velocities
+template <isQuantity Q>
+Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
+to_linear(
+    Quantity<
+    typename Q::mass, 
+    typename Q::length, 
+    typename Q::time, 
+    typename Q::current,
+    typename Q::angle> angular, 
+    Length diameter) {
+    return unit_cast<
+        Quantity<
+        typename Q::mass, 
+        typename Q::angle, 
+        typename Q::time, 
+        typename Q::current, 
+        typename Q::length>
+    >(angular * (diameter / 2.0));
+}
+
+// Convert an linear unit `Q` to a angular unit correctly;
+// mostly useful for velocities
+template <isQuantity Q>
+Quantity<typename Q::mass, typename Q::angle, typename Q::time, typename Q::current, typename Q::length>
+to_angular(
+    Quantity<
+    typename Q::mass, 
+    typename Q::length, 
+    typename Q::time, 
+    typename Q::current,
+    typename Q::angle> linear, 
+    Length diameter) {
+    return unit_cast<
+        Quantity<
+        typename Q::mass, 
+        typename Q::angle, 
+        typename Q::time, 
+        typename Q::current, 
+        typename Q::length>
+    >(linear / (diameter / 2.0));
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,9 @@ void initialize() {
     num = 0.0;
     a.theta().convert(deg);
     to_cDeg(a.theta());
+
+    Length x = 1_in;
+    Angle y = unit_cast<Angle>(x);
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,9 @@ void initialize() {
     a.theta().convert(deg);
     to_cDeg(a.theta());
 
-    Length x = 1_in;
-    Angle y = unit_cast<Angle>(x);
+    Length x = unit_cast<Length>(num);
+    Angle y = to_angular<Length>(x, 2_cm);
+    Length z = to_linear<Angle>(y, 2_cm);
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,8 +35,8 @@ void initialize() {
     to_cDeg(a.theta());
 
     Length x = unit_cast<Length>(num);
-    Angle y = to_angular<Length>(x, 2_cm);
-    Length z = to_linear<Angle>(y, 2_cm);
+    Angle y = toAngular<Length>(x, 2_cm);
+    Length z = toLinear<Angle>(y, 2_cm);
 }
 
 /**


### PR DESCRIPTION
Adds:
 - `unit_cast` for un(type)safely converting between units, which is necessary for certain algorithms
 - `toLinear` for safely and correctly converting an angular unit value into a linear unit value eg. `AngularVelocity` -> `LinearVelocity`
 - `toAngular` for safely and correctly converting an linear unit value into a angular unit value eg. `LinearVelocity` -> `AngularVelocity`