### PR TITLE
Mark constructors `explicit`

### DIFF
--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -35,14 +35,14 @@ template <TYPENAMES> class Quantity {
          *
          * This constructor initializes the value to 0
          */
-        constexpr Quantity() : value(0) {}
+        explicit constexpr Quantity() : value(0) {}
 
         /**
          * @brief construct a new Quantity object
          *
          * @param value the value to initialize the quantity with
          */
-        constexpr Quantity(double value) : value(value) {}
+        explicit constexpr Quantity(double value) : value(value) {}
 
         /**
          * @brief construct a new Quantity object

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ void initialize() {
     pros::lcd::set_text(1, "Hello PROS User!");
     pros::lcd::register_btn1_cb(on_center_button);
     units::Vector2D<AngularAcceleration> a(1_rpm2, 2_rpm2);
-    Number num = 1.0;
+    Number num = Number(1.0);
     num = 0.0;
     a.theta().convert(deg);
     to_cDeg(a.theta());


### PR DESCRIPTION
Marks the constructors for `Quantity` explicit to prevent code like this: 
```c++
// all good
auto example(Length x, Angle y) {
    return x / y;
}

// BAD!
// values are implicitly converted into units via the constructor! could be very confusing
example(1, 2)

// GOOD
example(1_in, 2_deg)
```
from compiling with out specified units