### PR TITLE
:pencil2: Fix Spelling of Temperature Units

### DIFF
--- a/include/units/Temperature.hpp
+++ b/include/units/Temperature.hpp
@@ -11,17 +11,17 @@ constexpr Temperature operator""_kelvin(long double value) { return Temperature(
 
 constexpr Temperature operator""_kelvin(unsigned long long value) { return Temperature(static_cast<double>(value)); }
 
-constexpr Temperature operator""_celcius(long double value) { return Temperature(static_cast<double>(value) + 273.15); }
+constexpr Temperature operator""_celsius(long double value) { return Temperature(static_cast<double>(value) + 273.15); }
 
-constexpr Temperature operator""_celcius(unsigned long long value) {
+constexpr Temperature operator""_celsius(unsigned long long value) {
     return Temperature(static_cast<double>(value) + 273.15);
 }
 
-constexpr Temperature operator""_farenheight(long double value) {
+constexpr Temperature operator""_fahrenheit(long double value) {
     return Temperature((static_cast<double>(value) - 32) * (5.0 / 9.0) + 273.5);
 }
 
-constexpr Temperature operator""_farenheight(unsigned long long value) {
+constexpr Temperature operator""_fahrenheit(unsigned long long value) {
     return Temperature((static_cast<double>(value) - 32) * (5.0 / 9.0) + 273.5);
 }
 
@@ -31,12 +31,12 @@ constexpr inline Temperature from_kelvin(double value) { return Temperature(valu
 
 constexpr inline double to_kelvin(Temperature quantity) { return quantity.val(); }
 
-constexpr inline Temperature from_celcius(double value) { return Temperature(value + 273.15); }
+constexpr inline Temperature from_celsius(double value) { return Temperature(value + 273.15); }
 
-constexpr inline double to_celcius(Temperature quantity) { return quantity.val() - 273.15; }
+constexpr inline double to_celsius(Temperature quantity) { return quantity.val() - 273.15; }
 
-constexpr inline Temperature from_farenheight(double value) { return Temperature((value - 32) * (5.0 / 9.0) + 273.15); }
+constexpr inline Temperature from_fahrenheit(double value) { return Temperature((value - 32) * (5.0 / 9.0) + 273.15); }
 
-constexpr inline double to_farenheight(Temperature quantity) { return (quantity.val() - 273.15) * (9.0 / 5.0) + 32; }
+constexpr inline double to_fahrenheit(Temperature quantity) { return (quantity.val() - 273.15) * (9.0 / 5.0) + 32; }
 
 } // namespace units


### PR DESCRIPTION
#### Overview

Celsius and Fahrenheit is both misspelled. Currently they are spelled as `Celcius` instead of `Celsius` and `Farenheight` instead of `Fahrenheit`

#### Test Plan

- [X] compiles

#### Additional Notes

i found this pretty funny