### PR TITLE
Generate nominal types instead of aliases (error improvement)

### DIFF
--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -197,11 +197,27 @@ template <isQuantity Q> constexpr bool operator>(const Q& lhs, const Q& rhs) {
 }
 
 #define NEW_UNIT(Name, suffix, m, l, t, i, a, o, j, n)                                                                 \
-    using Name = Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,    \
-                          std::ratio<j>, std::ratio<n>>;                                                               \
+    class Name : public Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,            \
+                                 std::ratio<o>, std::ratio<j>, std::ratio<n>> {                                        \
+        public:                                                                                                        \
+            explicit constexpr Name(double value)                                                                      \
+                : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
+                           std::ratio<j>, std::ratio<n>>(value) {}                                                     \
+            constexpr Name(Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,         \
+                                    std::ratio<o>, std::ratio<j>, std::ratio<n>>                                       \
+                               value)                                                                                  \
+                : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
+                           std::ratio<j>, std::ratio<n>>(value) {};                                                    \
+    };                                                                                                                 \
     constexpr Name suffix = Name(1.0);                                                                                 \
-    constexpr Name operator""_##suffix(long double value) { return Name(static_cast<double>(value)); }                 \
-    constexpr Name operator""_##suffix(unsigned long long value) { return Name(static_cast<double>(value)); }          \
+    constexpr Name operator""_##suffix(long double value) {                                                            \
+        return Name(Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, \
+                             std::ratio<j>, std::ratio<n>>(static_cast<double>(value)));                               \
+    }                                                                                                                  \
+    constexpr Name operator""_##suffix(unsigned long long value) {                                                     \
+        return Name(Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, \
+                             std::ratio<j>, std::ratio<n>>(static_cast<double>(value)));                               \
+    }                                                                                                                  \
     inline std::ostream& operator<<(std::ostream& os, const Name& quantity) {                                          \
         os << quantity.internal() << "_" << #suffix;                                                                   \
         return os;                                                                                                     \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ void initialize() {
     pros::lcd::register_btn1_cb(on_center_button);
     units::Vector2D<AngularAcceleration> a(1_rpm2, 2_rpm2);
     Number num = Number(1.0);
-    num = 0.0;
+    num = Number(0.0);
     a.theta().convert(deg);
     to_cDeg(a.theta());
 


### PR DESCRIPTION
Modifies the macros to generate nominal types instead of type aliases. It generates subtypes of `Quantity` with an implicit constructor from `Quantity` to the new type, meaning that code using units can stay exactly the same.

This greatly improves errors in many cases:

Example of old error:
![old_error](https://github.com/LemLib/units/assets/11135808/c111527e-1a64-453e-9df1-555f065d2af7)

With these changes, the same code generates this error:
![new_error](https://github.com/LemLib/units/assets/11135808/1a880d31-659d-41ff-95b1-c67a07eed7c6)
