### PR TITLE
Named types for type level operators (error improvement 2)

### DIFF
--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -111,13 +111,11 @@ class Quantity {
         }
 };
 
-template<typename Q>
-struct NamedTable {
-    using Named = Q;
+template <typename Q> struct NamedTable {
+        using Named = Q;
 };
 
-template<typename Q>
-using Named = typename NamedTable<Q>::Named;
+template <typename Q> using Named = typename NamedTable<Q>::Named;
 
 // quantity checker. Used by the isQuantity concept
 template <typename Mass = std::ratio<0>, typename Length = std::ratio<0>, typename Time = std::ratio<0>,
@@ -142,22 +140,22 @@ template <isQuantity Q1, isQuantity Q2> using Multiplied = Named<Quantity<
 
 template <isQuantity Q1, isQuantity Q2> using Divided =
     Named<Quantity<std::ratio_subtract<typename Q1::mass, typename Q2::mass>,
-             std::ratio_subtract<typename Q1::length, typename Q2::length>,
-             std::ratio_subtract<typename Q1::time, typename Q2::time>,
-             std::ratio_subtract<typename Q1::current, typename Q2::current>,
-             std::ratio_subtract<typename Q1::angle, typename Q2::angle>,
-             std::ratio_subtract<typename Q1::temperature, typename Q2::temperature>,
-             std::ratio_subtract<typename Q1::luminosity, typename Q2::luminosity>,
-             std::ratio_subtract<typename Q1::moles, typename Q2::moles>>>;
+                   std::ratio_subtract<typename Q1::length, typename Q2::length>,
+                   std::ratio_subtract<typename Q1::time, typename Q2::time>,
+                   std::ratio_subtract<typename Q1::current, typename Q2::current>,
+                   std::ratio_subtract<typename Q1::angle, typename Q2::angle>,
+                   std::ratio_subtract<typename Q1::temperature, typename Q2::temperature>,
+                   std::ratio_subtract<typename Q1::luminosity, typename Q2::luminosity>,
+                   std::ratio_subtract<typename Q1::moles, typename Q2::moles>>>;
 
-template <isQuantity Q, typename factor> using Exponentiated =
-    Named<Quantity<std::ratio_multiply<typename Q::mass, factor>, std::ratio_multiply<typename Q::length, factor>,
+template <isQuantity Q, typename factor> using Exponentiated = Named<
+    Quantity<std::ratio_multiply<typename Q::mass, factor>, std::ratio_multiply<typename Q::length, factor>,
              std::ratio_multiply<typename Q::time, factor>, std::ratio_multiply<typename Q::current, factor>,
              std::ratio_multiply<typename Q::angle, factor>, std::ratio_multiply<typename Q::temperature, factor>,
              std::ratio_multiply<typename Q::luminosity, factor>, std::ratio_multiply<typename Q::moles, factor>>>;
 
-template <isQuantity Q, typename quotient> using Rooted =
-    Named<Quantity<std::ratio_divide<typename Q::mass, quotient>, std::ratio_divide<typename Q::length, quotient>,
+template <isQuantity Q, typename quotient> using Rooted = Named<
+    Quantity<std::ratio_divide<typename Q::mass, quotient>, std::ratio_divide<typename Q::length, quotient>,
              std::ratio_divide<typename Q::time, quotient>, std::ratio_divide<typename Q::current, quotient>,
              std::ratio_divide<typename Q::angle, quotient>, std::ratio_divide<typename Q::temperature, quotient>,
              std::ratio_divide<typename Q::luminosity, quotient>, std::ratio_divide<typename Q::moles, quotient>>>;
@@ -217,10 +215,10 @@ template <isQuantity Q> constexpr bool operator>(const Q& lhs, const Q& rhs) {
                 : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
                            std::ratio<j>, std::ratio<n>>(value) {};                                                    \
     };                                                                                                                 \
-    template<>\
-    struct NamedTable<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, std::ratio<j>, std::ratio<n>>> {\
-        using Named = Name;\
-    };\
+    template <> struct NamedTable<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,  \
+                                           std::ratio<o>, std::ratio<j>, std::ratio<n>>> {                             \
+            using Named = Name;                                                                                        \
+    };                                                                                                                 \
     constexpr Name suffix = Name(1.0);                                                                                 \
     constexpr Name operator""_##suffix(long double value) {                                                            \
         return Name(Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, \

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -111,6 +111,14 @@ class Quantity {
         }
 };
 
+template<typename Q>
+struct NamedTable {
+    using Named = Q;
+};
+
+template<typename Q>
+using Named = typename NamedTable<Q>::Named;
+
 // quantity checker. Used by the isQuantity concept
 template <typename Mass = std::ratio<0>, typename Length = std::ratio<0>, typename Time = std::ratio<0>,
           typename Current = std::ratio<0>, typename Angle = std::ratio<0>, typename Temperature = std::ratio<0>,
@@ -124,35 +132,35 @@ concept isQuantity = requires(Q q) { quantityChecker(q); };
 // Un(type)safely coerce the a unit into a different unit
 template <isQuantity Q1, isQuantity Q2> constexpr inline Q1 unit_cast(Q2 quantity) { return Q1(quantity.internal()); }
 
-template <isQuantity Q1, isQuantity Q2> using Multiplied = Quantity<
+template <isQuantity Q1, isQuantity Q2> using Multiplied = Named<Quantity<
     std::ratio_add<typename Q1::mass, typename Q2::mass>, std::ratio_add<typename Q1::length, typename Q2::length>,
     std::ratio_add<typename Q1::time, typename Q2::time>, std::ratio_add<typename Q1::current, typename Q2::current>,
     std::ratio_add<typename Q1::angle, typename Q2::angle>,
     std::ratio_add<typename Q1::temperature, typename Q2::temperature>,
     std::ratio_add<typename Q1::luminosity, typename Q2::luminosity>,
-    std::ratio_add<typename Q1::moles, typename Q2::moles>>;
+    std::ratio_add<typename Q1::moles, typename Q2::moles>>>;
 
 template <isQuantity Q1, isQuantity Q2> using Divided =
-    Quantity<std::ratio_subtract<typename Q1::mass, typename Q2::mass>,
+    Named<Quantity<std::ratio_subtract<typename Q1::mass, typename Q2::mass>,
              std::ratio_subtract<typename Q1::length, typename Q2::length>,
              std::ratio_subtract<typename Q1::time, typename Q2::time>,
              std::ratio_subtract<typename Q1::current, typename Q2::current>,
              std::ratio_subtract<typename Q1::angle, typename Q2::angle>,
              std::ratio_subtract<typename Q1::temperature, typename Q2::temperature>,
              std::ratio_subtract<typename Q1::luminosity, typename Q2::luminosity>,
-             std::ratio_subtract<typename Q1::moles, typename Q2::moles>>;
+             std::ratio_subtract<typename Q1::moles, typename Q2::moles>>>;
 
 template <isQuantity Q, typename factor> using Exponentiated =
-    Quantity<std::ratio_multiply<typename Q::mass, factor>, std::ratio_multiply<typename Q::length, factor>,
+    Named<Quantity<std::ratio_multiply<typename Q::mass, factor>, std::ratio_multiply<typename Q::length, factor>,
              std::ratio_multiply<typename Q::time, factor>, std::ratio_multiply<typename Q::current, factor>,
              std::ratio_multiply<typename Q::angle, factor>, std::ratio_multiply<typename Q::temperature, factor>,
-             std::ratio_multiply<typename Q::luminosity, factor>, std::ratio_multiply<typename Q::moles, factor>>;
+             std::ratio_multiply<typename Q::luminosity, factor>, std::ratio_multiply<typename Q::moles, factor>>>;
 
 template <isQuantity Q, typename quotient> using Rooted =
-    Quantity<std::ratio_divide<typename Q::mass, quotient>, std::ratio_divide<typename Q::length, quotient>,
+    Named<Quantity<std::ratio_divide<typename Q::mass, quotient>, std::ratio_divide<typename Q::length, quotient>,
              std::ratio_divide<typename Q::time, quotient>, std::ratio_divide<typename Q::current, quotient>,
              std::ratio_divide<typename Q::angle, quotient>, std::ratio_divide<typename Q::temperature, quotient>,
-             std::ratio_divide<typename Q::luminosity, quotient>, std::ratio_divide<typename Q::moles, quotient>>;
+             std::ratio_divide<typename Q::luminosity, quotient>, std::ratio_divide<typename Q::moles, quotient>>>;
 
 template <isQuantity Q> constexpr Q operator+(Q lhs, Q rhs) { return Q(lhs.internal() + rhs.internal()); }
 
@@ -209,6 +217,10 @@ template <isQuantity Q> constexpr bool operator>(const Q& lhs, const Q& rhs) {
                 : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
                            std::ratio<j>, std::ratio<n>>(value) {};                                                    \
     };                                                                                                                 \
+    template<>\
+    struct NamedTable<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, std::ratio<j>, std::ratio<n>>> {\
+        using Named = Name;\
+    };\
     constexpr Name suffix = Name(1.0);                                                                                 \
     constexpr Name operator""_##suffix(long double value) {                                                            \
         return Name(Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>, \

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -111,11 +111,11 @@ class Quantity {
         }
 };
 
-template <typename Q> struct NamedTable {
+template <typename Q> struct LookupName {
         using Named = Q;
 };
 
-template <typename Q> using Named = typename NamedTable<Q>::Named;
+template <typename Q> using Named = typename LookupName<Q>::Named;
 
 // quantity checker. Used by the isQuantity concept
 template <typename Mass = std::ratio<0>, typename Length = std::ratio<0>, typename Time = std::ratio<0>,
@@ -215,7 +215,7 @@ template <isQuantity Q> constexpr bool operator>(const Q& lhs, const Q& rhs) {
                 : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
                            std::ratio<j>, std::ratio<n>>(value) {};                                                    \
     };                                                                                                                 \
-    template <> struct NamedTable<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,  \
+    template <> struct LookupName<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,  \
                                            std::ratio<o>, std::ratio<j>, std::ratio<n>>> {                             \
             using Named = Name;                                                                                        \
     };                                                                                                                 \


### PR DESCRIPTION
In the previous error improvement, the units system was changed to generate named classes for quantities that can be used interchangeably with the structural `Quantity<>` type. This PR allows type level quantity manipulations such as `Multiplied<Q1, Q2>`, `Divided<Q1, Q2>`, `Exponentiated<Q, N>` and `Rooted<Q, N>` to return the named classes (if possible) rather than the generic `Quantity<>` class.

It does this by generating a "compile time type function" from the corresponding `Quantity<>` class to it's named counterpart when the `NEW_UNIT` macro is invoked. Then with this function we can created a wrapper `Named<Q>` that will produce the named version of a quantity type if it exists.

For example this offending code:
![offending_code](https://github.com/LemLib/units/assets/11135808/05639293-58f4-4307-939b-c79620ac1502)

previously generated this error:
![old_error_2](https://github.com/LemLib/units/assets/11135808/958b9868-1d25-4582-96b7-e3bc51c1c554)

with this change, it now generates this error:
![new_error_2](https://github.com/LemLib/units/assets/11135808/d19bbc2c-abbf-4dc4-8c1a-272a04bae69f)

