### PR TITLE
:bug: Force .a file creation

### DIFF
--- a/src/units/dummy.cpp
+++ b/src/units/dummy.cpp
@@ -2,3 +2,11 @@
 // otherwise units does not compile reliably on all platforms
 // and the pros conductor will not let you create a template if there is
 // no .a file
+
+// a global, volatile variable in an anonymous namespace
+// its put in an anonymous namespace to guarantee that there won't be any
+// linker errors
+// 10/10 codebase (i don't feel like PRing a fix to PROS, make is scary)
+namespace {
+volatile char dummy_var;
+}


### PR DESCRIPTION
#### Overview
Force the creation of a `units.a` file

#### Motivation
The template can't be compiled reliably on all platforms if no `.a` file is produced

#### Implementation
A dummy source file is created, and in that source file is an anonymous namespace with a volatile global variable. This forces the creation of a `.a` file yet won't cause any potential linker errors.

```c++
// src/dummy.cpp

namespace {
volatile char dummy_var;
}
```