### PR TITLE
:sparkles: convert Number to unit using `from_##`

### DIFF
--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -101,25 +101,37 @@ static inline Angle constrainAngle180(Angle in) {
 // Standard orientation
 constexpr inline Angle from_stRad(double value) { return Angle(value); }
 
+constexpr inline Angle from_stRad(Number value) { return Angle(value.internal()); }
+
 constexpr inline double to_stRad(Angle quantity) { return quantity.internal(); }
 
 constexpr inline Angle from_stDeg(double value) { return value * deg; }
 
+constexpr inline Angle from_stDeg(Number value) { return value * deg; }
+
 constexpr inline double to_stDeg(Angle quantity) { return quantity.convert(deg); }
 
 constexpr inline Angle from_stRot(double value) { return value * rot; }
+
+constexpr inline Angle from_stRot(Number value) { return value * rot; }
 
 constexpr inline double to_stRot(Angle quantity) { return quantity.convert(rot); }
 
 // Compass orientation
 constexpr inline Angle from_cRad(double value) { return 90 * deg - Angle(value); }
 
+constexpr inline Angle from_cRad(Number value) { return 90 * deg - Angle(value.internal()); }
+
 constexpr inline double to_cRad(Angle quantity) { return quantity.internal(); }
 
 constexpr inline Angle from_cDeg(double value) { return (90 - value) * deg; }
 
+constexpr inline Angle from_cDeg(Number value) { return (90 - value.internal()) * deg; }
+
 constexpr inline double to_cDeg(Angle quantity) { return (90 * deg - quantity).convert(deg); }
 
 constexpr inline Angle from_cRot(double value) { return (90 - value) * deg; }
+
+constexpr inline Angle from_cRot(Number value) { return (90 - value.internal()) * deg; }
 
 constexpr inline double to_cRot(Angle quantity) { return (90 * deg - quantity).convert(rot); }

--- a/include/units/Temperature.hpp
+++ b/include/units/Temperature.hpp
@@ -50,13 +50,21 @@ namespace units {
 
 constexpr inline Temperature from_kelvin(double value) { return Temperature(value); }
 
+constexpr inline Temperature from_kelvin(Number value) { return Temperature(value.internal()); }
+
 constexpr inline double to_kelvin(Temperature quantity) { return quantity.internal(); }
 
 constexpr inline Temperature from_celsius(double value) { return Temperature(value + 273.15); }
 
+constexpr inline Temperature from_celsius(Number value) { return Temperature(value.internal() + 273.15); }
+
 constexpr inline double to_celsius(Temperature quantity) { return quantity.internal() - 273.15; }
 
 constexpr inline Temperature from_fahrenheit(double value) { return Temperature((value - 32) * (5.0 / 9.0) + 273.15); }
+
+constexpr inline Temperature from_fahrenheit(Number value) {
+    return Temperature((value.internal() - 32) * (5.0 / 9.0) + 273.15);
+}
 
 constexpr inline double to_fahrenheit(Temperature quantity) {
     return (quantity.internal() - 273.15) * (9.0 / 5.0) + 32;

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -299,6 +299,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     constexpr Name operator""_##suffix(long double value) { return static_cast<double>(value) * multiple; }            \
     constexpr Name operator""_##suffix(unsigned long long value) { return static_cast<double>(value) * multiple; }     \
     constexpr inline Name from_##suffix(double value) { return value * multiple; }                                     \
+    constexpr inline Name from_##suffix(Number value) { return value.internal() * multiple; }                          \
     constexpr inline double to_##suffix(Name quantity) { return quantity.convert(multiple); }
 
 #define NEW_METRIC_PREFIXES(Name, base)                                                                                \


### PR DESCRIPTION
#### Overview
Make it possible to construct units from a Number. 
Example:
```c++
Number number(a);
Angle angle = from_stRot(number);
```