### PR TITLE
:sparkles: Enhanced Vector Class

### DIFF
--- a/include/units/Pose.hpp
+++ b/include/units/Pose.hpp
@@ -25,7 +25,7 @@ template <typename derivatives> class AbstractPose
          *
          * This constructor initializes x, y, and orientation to 0
          */
-        AbstractPose() : Vector(), orientation(0.0) {}
+        constexpr AbstractPose() : Vector(), orientation(0.0) {}
 
         /**
          * @brief Construct a new Pose object
@@ -34,7 +34,7 @@ template <typename derivatives> class AbstractPose
          *
          * @param v position
          */
-        AbstractPose(Vector v) : Vector(v), orientation(0.0) {}
+        constexpr AbstractPose(Vector v) : Vector(v), orientation(0.0) {}
 
         /**
          * @brief Construct a new Pose object
@@ -42,7 +42,7 @@ template <typename derivatives> class AbstractPose
          * @param v position
          * @param orientation orientation
          */
-        AbstractPose(Vector v, Divided<Angle, Exponentiated<Time, derivatives>> orientation)
+        constexpr AbstractPose(Vector v, Divided<Angle, Exponentiated<Time, derivatives>> orientation)
             : Vector(v), orientation(orientation) {}
 
         /**
@@ -53,7 +53,7 @@ template <typename derivatives> class AbstractPose
          * @param x x position
          * @param y y position
          */
-        AbstractPose(Len x, Len y) : Vector(x, y), orientation(0.0) {}
+        constexpr AbstractPose(Len x, Len y) : Vector(x, y), orientation(0.0) {}
 
         /**
          * @brief Construct a new Pose object
@@ -62,7 +62,7 @@ template <typename derivatives> class AbstractPose
          * @param y y position
          * @param orientation orientation
          */
-        AbstractPose(Len x, Len y, Divided<Angle, Exponentiated<Time, derivatives>> orientation)
+        constexpr AbstractPose(Len x, Len y, Divided<Angle, Exponentiated<Time, derivatives>> orientation)
             : Vector(x, y), orientation(orientation) {}
 };
 

--- a/include/units/Pose.hpp
+++ b/include/units/Pose.hpp
@@ -64,13 +64,6 @@ template <typename derivatives> class AbstractPose
          */
         AbstractPose(Len x, Len y, Divided<Angle, Exponentiated<Time, derivatives>> orientation)
             : Vector(x, y), orientation(orientation) {}
-
-        /**
-         * @brief Get the orientation
-         *
-         * @return Angle orientation
-         */
-        Divided<Angle, Exponentiated<Time, derivatives>> getOrientation() const { return orientation; }
 };
 
 // Position Pose (Length, Angle)

--- a/include/units/Pose.hpp
+++ b/include/units/Pose.hpp
@@ -70,16 +70,7 @@ template <typename derivatives> class AbstractPose
          *
          * @return Angle orientation
          */
-        Divided<Angle, Exponentiated<Time, derivatives>> getOrientation() { return orientation; }
-
-        /**
-         * @brief Set the orientation
-         *
-         * @param orientation orientation
-         */
-        void setOrientation(Divided<Angle, Exponentiated<Time, derivatives>> orientation) {
-            this->orientation = orientation;
-        }
+        Divided<Angle, Exponentiated<Time, derivatives>> getOrientation() const { return orientation; }
 };
 
 // Position Pose (Length, Angle)

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -65,7 +65,9 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> operator+(const Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
+        constexpr Vector2D<T> operator+(const Vector2D<T>& other) const {
+            return Vector2D<T>(x + other.x, y + other.y);
+        }
 
         /**
          * @brief - operator overload
@@ -76,7 +78,9 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> operator-(const Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
+        constexpr Vector2D<T> operator-(const Vector2D<T>& other) const {
+            return Vector2D<T>(x - other.x, y - other.y);
+        }
 
         /**
          * @brief * operator overload
@@ -231,7 +235,9 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return T
          */
-        constexpr T distanceTo(const Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
+        constexpr T distanceTo(const Vector2D<T>& other) const {
+            return sqrt(square(x - other.x, 2) + square(y - other.y, 2));
+        }
 
         /**
          * @brief normalize the vector

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -194,19 +194,6 @@ template <isQuantity T> class Vector2D {
         constexpr T magnitude() const { return sqrt(square(this->x) + square(this->y)); }
 
         /**
-         * @brief difference between two vectors
-         *
-         * This function calculates the difference between two vectors
-         * a.vectorTo(b) = {b.x - a.x, b.y - a.y}
-         *
-         * @param other the other vector
-         * @return Vector2D<T>
-         */
-        constexpr Vector2D<T> vectorTo(const Vector2D<T>& other) const {
-            return Vector2D<T>(other.x - this->x, other.y - this->y);
-        }
-
-        /**
          * @brief the angle between two vectors
          *
          * @param other the other vector

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -57,9 +57,8 @@ template <isQuantity T> class Vector2D {
         constexpr static Vector2D unitVector(Angle t) { return fromPolar(t, (T)1.0); }
 
         /**
-         * @brief + operator overload
+         * @brief + operator overload. Adds the x and y components of two vectors
          *
-         * This operator adds the x and y components of two vectors
          * {a, b} + {c, d} = {a + c, b + d}
          *
          * @param other vector to add
@@ -70,9 +69,8 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief - operator overload
+         * @brief - operator overload. Substracts the x and y components of two vectors
          *
-         * This operator subtracts the x and y components of two vectors
          * {a, b} - {c, d} = {a - c, b - d}
          *
          * @param other vector to subtract
@@ -83,31 +81,52 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief * operator overload
+         * @brief * operator overload. Multiplies a vector by a quantity
          *
-         * This operator multiplies the x and y components of a vector by a scalar
-         * a * {b, c} = {a * b, a * c}
+         * {a, b} * c = {a * c, b * c}
          *
-         * @param factor scalar to multiply by
-         * @return Vector2D<T>
+         * @tparam Q the type of quantity to multiply the vector with
+         * @tparam R the quantity type of the resulting vector
+         *
+         * @param factor the quantity to multiple the vector by
+         * @return Vector2D<R>
          */
-        constexpr Vector2D<T> operator*(double factor) const { return Vector2D<T>(this->x * factor, this->y * factor); }
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr Vector2D<R> operator*(Q factor) const {
+            return Vector2D<R>(this->x * factor, this->y * factor);
+        }
 
         /**
-         * @brief / operator overload
+         * @brief * operator overload. Finds the dot product of 2 Vector2D objects
          *
-         * This operator divides the x and y components of a vector by a scalar
+         * {a, b} * {c, d} = (a * c) + (b * d)
+         *
+         * @tparam Q the type of quantity to use for the other vector
+         * @tparam R the type of quantity to use for the result
+         * @param other the vector to calculate the dot product with
+         * @return R the dot product
+         */
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R operator*(const Vector2D<Q>& other) const {
+            return (this->x * other.x) + (this->y * other.y);
+        }
+
+        /**
+         * @brief / operator overload. Divides a vector by a quantity
+         *
          * {a, b} / c = {a / c, b / c}
          *
-         * @param factor scalar to divide by
+         * @tparam Q the type of quantity to divide the vector with
+         * @tparam R the quantity type of the resulting vector
+         *
+         * @param factor the quantity to divide the vector by
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> operator/(double factor) const { return Vector2D<T>(this->x / factor, this->y / factor); }
+        template <isQuantity Q, isQuantity R = Divided<T, Q>> Vector2D<R> constexpr operator/(Q factor) const {
+            return Vector2D<R>(this->x / factor, this->y / factor);
+        }
 
         /**
-         * @brief += operator overload
+         * @brief += operator overload. Adds the components of two vectors and stores the result
          *
-         * This operator adds the x and y components of two vectors and stores the result in the calling vector
          * {a, b} += {c, d} => {a + c, b + d}
          *
          * @param other vector to add
@@ -120,9 +139,8 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief -= operator overload
+         * @brief -= operator overload. Subtracts the components of two vectors and stores the result
          *
-         * This operator subtracts the x and y components of two vectors and stores the result in the calling vector
          * {a, b} -= {c, d} => {a - c, b - d}
          *
          * @param other vector to subtract
@@ -135,11 +153,9 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief *= operator overload
+         * @brief *= operator overload. Multiplies the components of a vector by a scalar and stores the result
          *
-         * This operator multiplies the x and y components of a vector by a scalar and stores the result in the
-         * calling vector
-         * a *= {b, c} => {a * b, a * c}
+         * {a, b} *= c => {a * c, b * c}
          *
          * @param factor scalar to multiply by
          * @return Vector2D<T>&
@@ -151,10 +167,8 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief /= operator overload
+         * @brief /= operator overload. Divides the components of a vector by a scalar and stores the result
          *
-         * This operator divides the x and y components of a vector by a scalar and stores the result in the
-         * calling vector
          * {a, b} /= c => {a / c, b / c}
          *
          * @param factor scalar to divide by
@@ -167,22 +181,7 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief dot product of 2 Vector2D objects
-         *
-         * This function calculates the dot product of two vectors
-         * a.dot(b) = (a.x * b.x) + (a.y * b.y)
-         *
-         * @tparam Q the type of quantity to use for the other vector
-         * @tparam R the type of quantity to use for the result
-         * @param other the vector to calculate the dot product with
-         * @return R the dot product
-         */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R dot(const Vector2D<Q>& other) const {
-            return (this->x * other.x) + (this->y * other.y);
-        }
-
-        /**
-         * @brief angle of the vector
+         * @brief angle of the vector from the origin
          *
          * @return Angle
          */
@@ -233,10 +232,7 @@ template <isQuantity T> class Vector2D {
          *
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> normalize() const {
-            const T m = magnitude();
-            return Vector2D<T>(this->x / m, this->y / m);
-        }
+        constexpr Vector2D<T> normalize() const { return (*this) / magnitude(); }
 
         /**
          * @brief rotate the vector by an angle
@@ -267,11 +263,7 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> rotatedBy(Angle angle) const {
-            const T m = magnitude();
-            const Angle t = theta() + angle;
-            return fromPolar(t, m);
-        }
+        constexpr Vector2D<T> rotatedBy(Angle angle) const { return fromPolar(theta() + angle, magnitude()); }
 
         /**
          * @brief get a copy of this vector rotated to an angle
@@ -279,11 +271,26 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> rotatedTo(Angle angle) const {
-            const T m = magnitude();
-            return fromPolar(angle, m);
-        }
+        constexpr Vector2D<T> rotatedTo(Angle angle) const { return fromPolar(angle, magnitude()); }
 };
+
+/**
+ * @brief * operator overload. Multiplies a scalar and a vector
+ *
+ * a * {b, c} = {a * b, a * c}
+ *
+ * @tparam Q1 the quantity type of the scalar
+ * @tparam Q2 the quantity type of the vector
+ * @tparam Q3 the type of quantity to use for the result
+ *
+ * @param lhs the scalar on the left hand side
+ * @param rhs the vector on the right hand side
+ * @return Q3 the product
+ */
+template <isQuantity Q1, isQuantity Q2, isQuantity Q3 = Multiplied<Q1, Q2>>
+constexpr Vector2D<Q3> operator*(Q1 lhs, const Vector2D<Q2>& rhs) {
+    return rhs * lhs;
+}
 
 // define some common vector types
 typedef Vector2D<Length> V2Position;

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "units/units.hpp"
 #include "units/Angle.hpp"
 
 namespace units {

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -80,6 +80,16 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
+         * @brief * operator overload. Multiplies a vector by a double
+         *
+         * {a, b} * c = {a * c, b * c}
+         *
+         * @param factor the double to multiple the vector by
+         * @return Vector2D<T>
+         */
+        constexpr Vector2D<T> operator*(double factor) const { return Vector2D<T>(this->x * factor, this->y * factor); }
+
+        /**
          * @brief * operator overload. Multiplies a vector by a quantity
          *
          * {a, b} * c = {a * c, b * c}
@@ -107,6 +117,16 @@ template <isQuantity T> class Vector2D {
         template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R operator*(const Vector2D<Q>& other) const {
             return (this->x * other.x) + (this->y * other.y);
         }
+
+        /**
+         * @brief / operator overload. Divides a vector by a double
+         *
+         * {a, b} / c = {a / c, b / c}
+         *
+         * @param factor the double to multiple the vector by
+         * @return Vector2D<T>
+         */
+        constexpr Vector2D<T> operator/(double factor) const { return Vector2D<T>(this->x / factor, this->y / factor); }
 
         /**
          * @brief / operator overload. Divides a vector by a quantity
@@ -261,7 +281,7 @@ template <isQuantity T> class Vector2D {
 };
 
 /**
- * @brief * operator overload. Multiplies a scalar and a vector
+ * @brief * operator overload. Multiplies a quantity and a vector
  *
  * a * {b, c} = {a * b, a * c}
  *
@@ -271,12 +291,25 @@ template <isQuantity T> class Vector2D {
  *
  * @param lhs the scalar on the left hand side
  * @param rhs the vector on the right hand side
- * @return Q3 the product
+ * @return Vector2D<Q3> the product
  */
 template <isQuantity Q1, isQuantity Q2, isQuantity Q3 = Multiplied<Q1, Q2>>
 constexpr Vector2D<Q3> operator*(Q1 lhs, const Vector2D<Q2>& rhs) {
     return rhs * lhs;
 }
+
+/**
+ * @brief * operator overload. Multiplies a double and a vector
+ *
+ * a * {b, c} = {a * b, a * c}
+ *
+ * @tparam Q the quantity type of the vector
+ *
+ * @param lhs the scalar on the left hand side
+ * @param rhs the vector on the right hand side
+ * @return Vector2D<Q> the product
+ */
+template <isQuantity Q> constexpr Vector2D<Q> operator*(double lhs, const Vector2D<Q>& rhs) { return rhs * lhs; }
 
 // define some common vector types
 typedef Vector2D<Length> V2Position;

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -65,7 +65,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>
          */
-        Vector2D<T> operator+(Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
+        Vector2D<T> operator+(const Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
 
         /**
          * @brief - operator overload
@@ -76,7 +76,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>
          */
-        Vector2D<T> operator-(Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
+        Vector2D<T> operator-(const Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
 
         /**
          * @brief * operator overload
@@ -109,7 +109,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator+=(Vector2D<T>& other) {
+        Vector2D<T>& operator+=(const Vector2D<T>& other) {
             x += other.x;
             y += other.y;
             return (*this);
@@ -124,7 +124,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator-=(Vector2D<T>& other) {
+        Vector2D<T>& operator-=(const Vector2D<T>& other) {
             x -= other.x;
             y -= other.y;
             return (*this);
@@ -173,7 +173,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector2D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(const Vector2D<Q>& other) const {
             return (x * other.x) + (y * other.y);
         }
 
@@ -188,7 +188,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the cross product with
          * @return R the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R cross(Vector2D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R cross(const Vector2D<Q>& other) const {
             return (x * other.y) - (y * other.x);
         }
 
@@ -215,7 +215,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Vector2D<T>
          */
-        Vector2D<T> vectorTo(Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
+        Vector2D<T> vectorTo(const Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
 
         /**
          * @brief the angle between two vectors
@@ -223,7 +223,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
+        Angle angleTo(const Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
 
         /**
          * @brief get the distance between two vectors
@@ -231,7 +231,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
+        T distanceTo(const Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
 
         /**
          * @brief normalize the vector

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -182,21 +182,6 @@ template <isQuantity T> class Vector2D {
         }
 
         /**
-         * @brief cross product of 2 Vector2D objects
-         *
-         * This function calculates the cross product of two vectors
-         * a.cross(b) = (a.x * b.y) - (a.y * b.x)
-         *
-         * @tparam Q the type of quantity to use for the other vector
-         * @tparam R the type of quantity to use for the result
-         * @param other the vector to calculate the cross product with
-         * @return R the cross product
-         */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R cross(const Vector2D<Q>& other) const {
-            return (x * other.y) - (y * other.x);
-        }
-
-        /**
          * @brief angle of the vector
          *
          * @return Angle

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -22,7 +22,7 @@ template <isQuantity T> class Vector2D {
          * This constructor initializes x and y to 0
          *
          */
-        Vector2D() : x(0.0), y(0.0) {}
+        constexpr Vector2D() : x(0.0), y(0.0) {}
 
         /**
          * @brief Construct a new Vector2D object
@@ -32,7 +32,7 @@ template <isQuantity T> class Vector2D {
          * @param nx x component
          * @param ny y component
          */
-        Vector2D(T nx, T ny) : x(nx), y(ny) {}
+        constexpr Vector2D(T nx, T ny) : x(nx), y(ny) {}
 
         /**
          * @brief Create a new Vector2D object from polar coordinates
@@ -42,7 +42,7 @@ template <isQuantity T> class Vector2D {
          * @param t angle
          * @param m magnitude
          */
-        static Vector2D fromPolar(Angle t, T m) {
+        constexpr static Vector2D fromPolar(Angle t, T m) {
             m = abs(m);
             t = constrainAngle360(t);
             return Vector2D<T>(m * cos(t), m * sin(t));
@@ -54,7 +54,7 @@ template <isQuantity T> class Vector2D {
          * @param t angle
          * @return Vector2D
          */
-        static Vector2D unitVector(Angle t) { return fromPolar(t, (T)1.0); }
+        constexpr static Vector2D unitVector(Angle t) { return fromPolar(t, (T)1.0); }
 
         /**
          * @brief + operator overload
@@ -65,7 +65,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>
          */
-        Vector2D<T> operator+(const Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
+        constexpr Vector2D<T> operator+(const Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
 
         /**
          * @brief - operator overload
@@ -76,7 +76,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>
          */
-        Vector2D<T> operator-(const Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
+        constexpr Vector2D<T> operator-(const Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
 
         /**
          * @brief * operator overload
@@ -87,7 +87,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to multiply by
          * @return Vector2D<T>
          */
-        Vector2D<T> operator*(double factor) const { return Vector2D<T>(x * factor, y * factor); }
+        constexpr Vector2D<T> operator*(double factor) const { return Vector2D<T>(x * factor, y * factor); }
 
         /**
          * @brief / operator overload
@@ -98,7 +98,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to divide by
          * @return Vector2D<T>
          */
-        Vector2D<T> operator/(double factor) const { return Vector2D<T>(x / factor, y / factor); }
+        constexpr Vector2D<T> operator/(double factor) const { return Vector2D<T>(x / factor, y / factor); }
 
         /**
          * @brief += operator overload
@@ -109,7 +109,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator+=(const Vector2D<T>& other) {
+        constexpr Vector2D<T>& operator+=(const Vector2D<T>& other) {
             x += other.x;
             y += other.y;
             return (*this);
@@ -124,7 +124,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator-=(const Vector2D<T>& other) {
+        constexpr Vector2D<T>& operator-=(const Vector2D<T>& other) {
             x -= other.x;
             y -= other.y;
             return (*this);
@@ -140,7 +140,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to multiply by
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator*=(double factor) {
+        constexpr Vector2D<T>& operator*=(double factor) {
             x *= factor;
             y *= factor;
             return (*this);
@@ -156,7 +156,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to divide by
          * @return Vector2D<T>&
          */
-        Vector2D<T>& operator/=(double factor) {
+        constexpr Vector2D<T>& operator/=(double factor) {
             x /= factor;
             y /= factor;
             return (*this);
@@ -173,7 +173,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(const Vector2D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R dot(const Vector2D<Q>& other) const {
             return (x * other.x) + (y * other.y);
         }
 
@@ -188,7 +188,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the cross product with
          * @return R the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R cross(const Vector2D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R cross(const Vector2D<Q>& other) const {
             return (x * other.y) - (y * other.x);
         }
 
@@ -197,14 +197,14 @@ template <isQuantity T> class Vector2D {
          *
          * @return Angle
          */
-        Angle theta() const { return atan2(y, x); }
+        constexpr Angle theta() const { return atan2(y, x); }
 
         /**
          * @brief magnitude of the vector
          *
          * @return T
          */
-        T magnitude() const { return sqrt(square(x) + square(y)); }
+        constexpr T magnitude() const { return sqrt(square(x) + square(y)); }
 
         /**
          * @brief difference between two vectors
@@ -215,7 +215,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Vector2D<T>
          */
-        Vector2D<T> vectorTo(const Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
+        constexpr Vector2D<T> vectorTo(const Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
 
         /**
          * @brief the angle between two vectors
@@ -223,7 +223,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(const Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
+        constexpr Angle angleTo(const Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
 
         /**
          * @brief get the distance between two vectors
@@ -231,7 +231,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(const Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
+        constexpr T distanceTo(const Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
 
         /**
          * @brief normalize the vector
@@ -240,7 +240,7 @@ template <isQuantity T> class Vector2D {
          *
          * @return Vector2D<T>
          */
-        Vector2D<T> normalize() const {
+        constexpr Vector2D<T> normalize() const {
             T m = magnitude();
             return Vector2D<T>(x / m, y / m);
         }
@@ -250,7 +250,7 @@ template <isQuantity T> class Vector2D {
          *
          * @param angle
          */
-        void rotateBy(Angle angle) {
+        constexpr void rotateBy(Angle angle) {
             T m = magnitude();
             Angle t = theta() + angle;
             x = m * cos(t);
@@ -262,7 +262,7 @@ template <isQuantity T> class Vector2D {
          *
          * @param angle
          */
-        void rotateTo(Angle angle) {
+        constexpr void rotateTo(Angle angle) {
             T m = magnitude();
             x = m * cos(angle);
             y = m * sin(angle);
@@ -274,7 +274,7 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        Vector2D<T> rotatedBy(Angle angle) const {
+        constexpr Vector2D<T> rotatedBy(Angle angle) const {
             T m = magnitude();
             Angle t = theta() + angle;
             return fromPolar(t, m);
@@ -286,7 +286,7 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        Vector2D<T> rotatedTo(Angle angle) const {
+        constexpr Vector2D<T> rotatedTo(Angle angle) const {
             T m = magnitude();
             return fromPolar(angle, m);
         }

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -66,7 +66,7 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>
          */
         constexpr Vector2D<T> operator+(const Vector2D<T>& other) const {
-            return Vector2D<T>(x + other.x, y + other.y);
+            return Vector2D<T>(this->x + other.x, this->y + other.y);
         }
 
         /**
@@ -79,7 +79,7 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>
          */
         constexpr Vector2D<T> operator-(const Vector2D<T>& other) const {
-            return Vector2D<T>(x - other.x, y - other.y);
+            return Vector2D<T>(this->x - other.x, this->y - other.y);
         }
 
         /**
@@ -91,7 +91,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to multiply by
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> operator*(double factor) const { return Vector2D<T>(x * factor, y * factor); }
+        constexpr Vector2D<T> operator*(double factor) const { return Vector2D<T>(this->x * factor, this->y * factor); }
 
         /**
          * @brief / operator overload
@@ -102,7 +102,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to divide by
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> operator/(double factor) const { return Vector2D<T>(x / factor, y / factor); }
+        constexpr Vector2D<T> operator/(double factor) const { return Vector2D<T>(this->x / factor, this->y / factor); }
 
         /**
          * @brief += operator overload
@@ -114,8 +114,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>&
          */
         constexpr Vector2D<T>& operator+=(const Vector2D<T>& other) {
-            x += other.x;
-            y += other.y;
+            this->x += other.x;
+            this->y += other.y;
             return (*this);
         }
 
@@ -129,8 +129,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>&
          */
         constexpr Vector2D<T>& operator-=(const Vector2D<T>& other) {
-            x -= other.x;
-            y -= other.y;
+            this->x -= other.x;
+            this->y -= other.y;
             return (*this);
         }
 
@@ -145,8 +145,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>&
          */
         constexpr Vector2D<T>& operator*=(double factor) {
-            x *= factor;
-            y *= factor;
+            this->x *= factor;
+            this->y *= factor;
             return (*this);
         }
 
@@ -161,8 +161,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>&
          */
         constexpr Vector2D<T>& operator/=(double factor) {
-            x /= factor;
-            y /= factor;
+            this->x /= factor;
+            this->y /= factor;
             return (*this);
         }
 
@@ -178,7 +178,7 @@ template <isQuantity T> class Vector2D {
          * @return R the dot product
          */
         template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R dot(const Vector2D<Q>& other) const {
-            return (x * other.x) + (y * other.y);
+            return (this->x * other.x) + (this->y * other.y);
         }
 
         /**
@@ -186,14 +186,14 @@ template <isQuantity T> class Vector2D {
          *
          * @return Angle
          */
-        constexpr Angle theta() const { return atan2(y, x); }
+        constexpr Angle theta() const { return atan2(this->y, this->x); }
 
         /**
          * @brief magnitude of the vector
          *
          * @return T
          */
-        constexpr T magnitude() const { return sqrt(square(x) + square(y)); }
+        constexpr T magnitude() const { return sqrt(square(this->x) + square(this->y)); }
 
         /**
          * @brief difference between two vectors
@@ -204,7 +204,9 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Vector2D<T>
          */
-        constexpr Vector2D<T> vectorTo(const Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
+        constexpr Vector2D<T> vectorTo(const Vector2D<T>& other) const {
+            return Vector2D<T>(other.x - this->x, other.y - this->y);
+        }
 
         /**
          * @brief the angle between two vectors
@@ -212,7 +214,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Angle
          */
-        constexpr Angle angleTo(const Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
+        constexpr Angle angleTo(const Vector2D<T>& other) const { return atan2(other.y - this->y, other.x - this->x); }
 
         /**
          * @brief get the distance between two vectors
@@ -221,7 +223,7 @@ template <isQuantity T> class Vector2D {
          * @return T
          */
         constexpr T distanceTo(const Vector2D<T>& other) const {
-            return sqrt(square(x - other.x, 2) + square(y - other.y, 2));
+            return sqrt(square(this->x - other.x, 2) + square(this->y - other.y, 2));
         }
 
         /**
@@ -232,8 +234,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>
          */
         constexpr Vector2D<T> normalize() const {
-            T m = magnitude();
-            return Vector2D<T>(x / m, y / m);
+            const T m = magnitude();
+            return Vector2D<T>(this->x / m, this->y / m);
         }
 
         /**
@@ -242,10 +244,10 @@ template <isQuantity T> class Vector2D {
          * @param angle
          */
         constexpr void rotateBy(Angle angle) {
-            T m = magnitude();
-            Angle t = theta() + angle;
-            x = m * cos(t);
-            y = m * sin(t);
+            const T m = magnitude();
+            const Angle t = theta() + angle;
+            this->x = m * cos(t);
+            this->y = m * sin(t);
         }
 
         /**
@@ -254,9 +256,9 @@ template <isQuantity T> class Vector2D {
          * @param angle
          */
         constexpr void rotateTo(Angle angle) {
-            T m = magnitude();
-            x = m * cos(angle);
-            y = m * sin(angle);
+            const T m = magnitude();
+            this->x = m * cos(angle);
+            this->y = m * sin(angle);
         }
 
         /**
@@ -266,8 +268,8 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>
          */
         constexpr Vector2D<T> rotatedBy(Angle angle) const {
-            T m = magnitude();
-            Angle t = theta() + angle;
+            const T m = magnitude();
+            const Angle t = theta() + angle;
             return fromPolar(t, m);
         }
 
@@ -278,7 +280,7 @@ template <isQuantity T> class Vector2D {
          * @return Vector2D<T>
          */
         constexpr Vector2D<T> rotatedTo(Angle angle) const {
-            T m = magnitude();
+            const T m = magnitude();
             return fromPolar(angle, m);
         }
 };

--- a/include/units/Vector2D.hpp
+++ b/include/units/Vector2D.hpp
@@ -65,7 +65,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to add
          * @return Vector2D<T>
          */
-        Vector2D<T> operator+(Vector2D<T>& other) { return Vector2D<T>(x + other.x, y + other.y); }
+        Vector2D<T> operator+(Vector2D<T>& other) const { return Vector2D<T>(x + other.x, y + other.y); }
 
         /**
          * @brief - operator overload
@@ -76,7 +76,7 @@ template <isQuantity T> class Vector2D {
          * @param other vector to subtract
          * @return Vector2D<T>
          */
-        Vector2D<T> operator-(Vector2D<T>& other) { return Vector2D<T>(x - other.x, y - other.y); }
+        Vector2D<T> operator-(Vector2D<T>& other) const { return Vector2D<T>(x - other.x, y - other.y); }
 
         /**
          * @brief * operator overload
@@ -87,7 +87,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to multiply by
          * @return Vector2D<T>
          */
-        Vector2D<T> operator*(double factor) { return Vector2D<T>(x * factor, y * factor); }
+        Vector2D<T> operator*(double factor) const { return Vector2D<T>(x * factor, y * factor); }
 
         /**
          * @brief / operator overload
@@ -98,7 +98,7 @@ template <isQuantity T> class Vector2D {
          * @param factor scalar to divide by
          * @return Vector2D<T>
          */
-        Vector2D<T> operator/(double factor) { return Vector2D<T>(x / factor, y / factor); }
+        Vector2D<T> operator/(double factor) const { return Vector2D<T>(x / factor, y / factor); }
 
         /**
          * @brief += operator overload
@@ -173,7 +173,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector2D<Q>& other) {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector2D<Q>& other) const {
             return (x * other.x) + (y * other.y);
         }
 
@@ -188,7 +188,7 @@ template <isQuantity T> class Vector2D {
          * @param other the vector to calculate the cross product with
          * @return R the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R cross(Vector2D<Q>& other) {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R cross(Vector2D<Q>& other) const {
             return (x * other.y) - (y * other.x);
         }
 
@@ -197,14 +197,14 @@ template <isQuantity T> class Vector2D {
          *
          * @return Angle
          */
-        Angle theta() { return atan2(y, x); }
+        Angle theta() const { return atan2(y, x); }
 
         /**
          * @brief magnitude of the vector
          *
          * @return T
          */
-        T magnitude() { return sqrt(square(x) + square(y)); }
+        T magnitude() const { return sqrt(square(x) + square(y)); }
 
         /**
          * @brief difference between two vectors
@@ -215,7 +215,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Vector2D<T>
          */
-        Vector2D<T> vectorTo(Vector2D<T>& other) { return Vector2D<T>(other.x - x, other.y - y); }
+        Vector2D<T> vectorTo(Vector2D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y); }
 
         /**
          * @brief the angle between two vectors
@@ -223,7 +223,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(Vector2D<T>& other) { return atan2(other.y - y, other.x - x); }
+        Angle angleTo(Vector2D<T>& other) const { return atan2(other.y - y, other.x - x); }
 
         /**
          * @brief get the distance between two vectors
@@ -231,7 +231,7 @@ template <isQuantity T> class Vector2D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(Vector2D<T>& other) { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
+        T distanceTo(Vector2D<T>& other) const { return sqrt(square(x - other.x, 2) + square(y - other.y, 2)); }
 
         /**
          * @brief normalize the vector
@@ -240,7 +240,7 @@ template <isQuantity T> class Vector2D {
          *
          * @return Vector2D<T>
          */
-        Vector2D<T> normalize() {
+        Vector2D<T> normalize() const {
             T m = magnitude();
             return Vector2D<T>(x / m, y / m);
         }
@@ -274,7 +274,7 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        Vector2D<T> rotatedBy(Angle angle) {
+        Vector2D<T> rotatedBy(Angle angle) const {
             T m = magnitude();
             Angle t = theta() + angle;
             return fromPolar(t, m);
@@ -286,7 +286,7 @@ template <isQuantity T> class Vector2D {
          * @param angle
          * @return Vector2D<T>
          */
-        Vector2D<T> rotatedTo(Angle angle) {
+        Vector2D<T> rotatedTo(Angle angle) const {
             T m = magnitude();
             return fromPolar(angle, m);
         }

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -80,6 +80,18 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
+         * @brief * operator overload. Multiplies a vector by a double
+         *
+         * {a, b} * c = {a * c, b * c}
+         *
+         * @param factor the double to multiple the vector by
+         * @return Vector2D<T>
+         */
+        constexpr Vector3D<T> operator*(double factor) const {
+            return Vector3D<T>(this->x * factor, this->y * factor, this->z * factor);
+        }
+
+        /**
          * @brief * operator overload. Multiplies a vector by a quantity
          *
          * {a, b, c} * d = {a * d, b * d, c * d}
@@ -92,6 +104,18 @@ template <isQuantity T> class Vector3D {
          */
         template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr Vector3D<R> operator*(Q factor) const {
             return Vector3D<R>(this->x * factor, this->y * factor, this->z * factor);
+        }
+
+        /**
+         * @brief / operator overload. Multiplies a vector by a double
+         *
+         * {a, b, c} / d = {a / d, b / d, c / d}
+         *
+         * @param factor the double to multiple the vector by
+         * @return Vector3D<T>
+         */
+        constexpr Vector3D<T> operator/(double factor) const {
+            return Vector3D<T>(this->x / factor, this->y / factor, this->z / factor);
         }
 
         /**
@@ -308,6 +332,19 @@ template <isQuantity Q1, isQuantity Q2, isQuantity Q3 = Multiplied<Q1, Q2>>
 constexpr Vector3D<Q3> operator*(Q1 lhs, const Vector3D<Q2>& rhs) {
     return rhs * lhs;
 }
+
+/**
+ * @brief * operator overload. Multiplies a double and a vector
+ *
+ * a * {b, c, d} = {a * b, a * c, a * d}
+ *
+ * @tparam Q the quantity type of the vector
+ *
+ * @param lhs the scalar on the left hand side
+ * @param rhs the vector on the right hand side
+ * @return Vector3D<Q> the product
+ */
+template <isQuantity Q> constexpr Vector3D<Q> operator*(double lhs, const Vector3D<Q>& rhs) { return rhs * lhs; }
 
 // define some common vector types
 typedef Vector3D<Length> V3Position;

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -42,7 +42,7 @@ template <isQuantity T> class Vector3D {
          * @param t angle
          * @param m magnitude
          */
-        static Vector3D fromPolar(Vector3D<Angle>& t, T m) {
+        static Vector3D fromPolar(const Vector3D<Angle>& t, T m) {
             m = m.abs();
             return Vector3D<T>(m * cos(t.x), m * cos(t.y), m * cos(t.z));
         }
@@ -53,7 +53,7 @@ template <isQuantity T> class Vector3D {
          * @param t angle
          * @return Vector3D
          */
-        static Vector3D unitVector(Vector3D<Angle> t) { return fromPolar(t, (T)1.0); }
+        static Vector3D unitVector(const Vector3D<Angle>& t) { return fromPolar(t, (T)1.0); }
 
         /**
          * @brief + operator overload
@@ -64,7 +64,9 @@ template <isQuantity T> class Vector3D {
          * @param other vector to add
          * @return Vector3D<T>
          */
-        Vector3D<T> operator+(Vector3D<T>& other) const { return Vector3D<T>(x + other.x, y + other.y, z + other.z); }
+        Vector3D<T> operator+(const Vector3D<T>& other) const {
+            return Vector3D<T>(x + other.x, y + other.y, z + other.z);
+        }
 
         /**
          * @brief - operator overload
@@ -75,7 +77,9 @@ template <isQuantity T> class Vector3D {
          * @param other vector to subtract
          * @return Vector3D<T>
          */
-        Vector3D<T> operator-(Vector3D<T>& other) const { return Vector3D<T>(x - other.x, y - other.y, z - other.z); }
+        Vector3D<T> operator-(const Vector3D<T>& other) const {
+            return Vector3D<T>(x - other.x, y - other.y, z - other.z);
+        }
 
         /**
          * @brief * operator overload
@@ -108,7 +112,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to add
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator+=(Vector3D<T>& other) {
+        Vector3D<T>& operator+=(const Vector3D<T>& other) {
             x += other.x;
             y += other.y;
             z += other.z;
@@ -124,7 +128,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to subtract
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator-=(Vector3D<T>& other) {
+        Vector3D<T>& operator-=(const Vector3D<T>& other) {
             x -= other.x;
             y -= other.y;
             z -= other.z;
@@ -176,7 +180,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector3D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(const Vector3D<Q>& other) const {
             return (x * other.x) + (y * other.y) + (z * other.z);
         }
 
@@ -193,7 +197,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the cross product with
          * @return Vector3D<R> the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> Vector3D<R> cross(Vector3D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> Vector3D<R> cross(const Vector3D<Q>& other) const {
             return Vector3D<R>(y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x);
         }
 
@@ -225,7 +229,9 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Vector3D<T>
          */
-        Vector3D<T> vectorTo(Vector3D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y, other.z - z); }
+        Vector3D<T> vectorTo(const Vector3D<T>& other) const {
+            return Vector2D<T>(other.x - x, other.y - y, other.z - z);
+        }
 
         /**
          * @brief the angle between two vectors
@@ -233,7 +239,9 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(Vector3D<T>& other) const { return units::acos(dot(other) / (magnitude() * other.magnitude())); }
+        Angle angleTo(const Vector3D<T>& other) const {
+            return units::acos(dot(other) / (magnitude() * other.magnitude()));
+        }
 
         /**
          * @brief get the distance between two vectors
@@ -241,7 +249,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(Vector3D<T>& other) const { return vectorTo(other).magnitude(); }
+        T distanceTo(const Vector3D<T>& other) const { return vectorTo(other).magnitude(); }
 
         /**
          * @brief normalize the vector
@@ -260,7 +268,7 @@ template <isQuantity T> class Vector3D {
          *
          * @param angle
          */
-        void rotateBy(Vector3D<Angle>& angle) {
+        void rotateBy(const Vector3D<Angle>& angle) {
             const T m = magnitude();
             const Vector3D<Angle> t = theta() + angle;
             x = m * cos(t.x);
@@ -273,7 +281,7 @@ template <isQuantity T> class Vector3D {
          *
          * @param angle
          */
-        void rotateTo(Vector3D<Angle>& angle) {
+        void rotateTo(const Vector3D<Angle>& angle) {
             const T m = magnitude();
             x = m * cos(angle.x);
             y = m * cos(angle.y);
@@ -286,7 +294,7 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        Vector3D<T> rotatedBy(Vector3D<Angle> angle) const {
+        Vector3D<T> rotatedBy(const Vector3D<Angle>& angle) const {
             T m = magnitude();
             Angle t = theta() + angle;
             return fromPolar(t, m);

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -221,21 +221,6 @@ template <isQuantity T> class Vector3D {
         constexpr T magnitude() const { return sqrt(square(this->x) + square(this->y) + square(this->z)); }
 
         /**
-         * @brief difference between two vectors
-         *
-         * TODO: figure out if this is even necessary, you could just use the - operator overload
-         *
-         * This function calculates the difference between two vectors
-         * a.vectorTo(b) = {b.x - a.x, b.y - a.y, b.z - a.z}
-         *
-         * @param other the other vector
-         * @return Vector3D<T>
-         */
-        constexpr Vector3D<T> vectorTo(const Vector3D<T>& other) const {
-            return Vector2D<T>(other.x - this->x, other.y - this->y, other.z - this->z);
-        }
-
-        /**
          * @brief the angle between two vectors
          *
          * @param other the other vector

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -56,9 +56,8 @@ template <isQuantity T> class Vector3D {
         constexpr static Vector3D unitVector(const Vector3D<Angle>& t) { return fromPolar(t, (T)1.0); }
 
         /**
-         * @brief + operator overload
+         * @brief + operator overload. Adds the components of two vectors
          *
-         * This operator adds the x, y, and z components of two vectors
          * {a, b, c} + {d, e, f} = {a + d, b + e, c + f}
          *
          * @param other vector to add
@@ -69,9 +68,8 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
-         * @brief - operator overload
+         * @brief - operator overload. Subtracts the components of two vectors
          *
-         * This operator subtracts the x, y, and z components of two vectors
          * {a, b, c} - {d, e, f} = {a - d, b - e, c - f}
          *
          * @param other vector to subtract
@@ -82,35 +80,38 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
-         * @brief * operator overload
+         * @brief * operator overload. Multiplies a vector by a quantity
          *
-         * This operator multiplies the x, y, and z components of a vector by a scalar
-         * a * {b, c, d} = {a * b, a * c, a * d}
+         * {a, b, c} * d = {a * d, b * d, c * d}
          *
-         * @param factor scalar to multiply by
-         * @return Vector3D<T>
+         * @tparam Q the type of quantity to multiply the vector with
+         * @tparam R the quantity type of the resulting vector
+         *
+         * @param factor the quantity to multiple the vector by
+         * @return Vector3D<R>
          */
-        constexpr Vector3D<T> operator*(double factor) const {
-            return Vector3D<T>(this->x * factor, this->y * factor, this->z * factor);
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr Vector3D<R> operator*(Q factor) const {
+            return Vector3D<R>(this->x * factor, this->y * factor, this->z * factor);
         }
 
         /**
-         * @brief / operator overload
+         * @brief / operator overload. Multiplies a vector by a quantity
          *
-         * This operator divides the x, y, and z components of a vector by a scalar
          * {a, b, c} / d = {a / d, b / d, c / d}
          *
-         * @param factor scalar to divide by
-         * @return Vector3D<T>
+         * @tparam Q the type of quantity to multiply the vector with
+         * @tparam R the quantity type of the resulting vector
+         *
+         * @param factor the quantity to multiple the vector by
+         * @return Vector3D<R>
          */
-        constexpr Vector3D<T> operator/(double factor) const {
-            return Vector3D<T>(this->x / factor, this->y / factor, this->z / factor);
+        template <isQuantity Q, isQuantity R = Divided<T, Q>> constexpr Vector3D<R> operator/(Q factor) const {
+            return Vector3D<R>(this->x / factor, this->y / factor, this->z / factor);
         }
 
         /**
-         * @brief += operator overload
+         * @brief += operator overload. Adds the components of two vectors and stores the result
          *
-         * This operator adds the x, y, and z components of two vectors and stores the result in the calling vector
          * {a, b, c} += {d, e, f} => {a + d, b + e, c + f}
          *
          * @param other vector to add
@@ -124,9 +125,8 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
-         * @brief -= operator overload
+         * @brief -= operator overload. Subtracts the components of two vectors and stores the result
          *
-         * This operator subtracts the x, y, and z components of two vectors and stores the result in the calling vector
          * {a, b, c} -= {d, e, f} => {a - d, b - e, c - f}
          *
          * @param other vector to subtract
@@ -140,10 +140,8 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
-         * @brief *= operator overload
+         * @brief *= operator overload. Multiplies the components of a vector by a scalar and stores the result.
          *
-         * This operator multiplies the x, y, and z components of a vector by a scalar and stores the result in the
-         * calling vector
          * a *= {b, c, d} => {a * b, a * c, a * d}
          *
          * @param factor scalar to multiply by
@@ -157,10 +155,8 @@ template <isQuantity T> class Vector3D {
         }
 
         /**
-         * @brief /= operator overload
+         * @brief /= operator overload. Divides the components of a vector by a scalar and stores the result
          *
-         * This operator divides the x, y, and z components of a vector by a scalar and stores the result in the
-         * calling vector
          * {a, b, c} /= d => {a / d, b / d, c / d}
          *
          * @param factor scalar to divide by
@@ -264,7 +260,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return Vector3D<T>
          */
-        constexpr Vector3D<T> normalize() { return *(this) / magnitude(); }
+        constexpr Vector3D<T> normalize() { return (*this) / magnitude(); }
 
         /**
          * @brief rotate the vector by an angle
@@ -298,9 +294,7 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> rotatedBy(const Vector3D<Angle>& angle) const {
-            const T m = magnitude();
-            const Angle t = theta() + angle;
-            return fromPolar(t, m);
+            return fromPolar(theta() + angle, magnitude());
         }
 
         /**
@@ -309,11 +303,26 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        constexpr Vector3D<T> rotatedTo(Angle angle) const {
-            const T m = magnitude();
-            return fromPolar(angle, m);
-        }
+        constexpr Vector3D<T> rotatedTo(Angle angle) const { return fromPolar(angle, magnitude()); }
 };
+
+/**
+ * @brief * operator overload. Multiplies a scalar and a vector
+ *
+ * a * {b, c, d} = {a * b, a * c, a * d}
+ *
+ * @tparam Q1 the quantity type of the scalar
+ * @tparam Q2 the quantity type of the vector
+ * @tparam Q3 the type of quantity to use for the result
+ *
+ * @param lhs the scalar on the left hand side
+ * @param rhs the vector on the right hand side
+ * @return Q3 the product
+ */
+template <isQuantity Q1, isQuantity Q2, isQuantity Q3 = Multiplied<Q1, Q2>>
+constexpr Vector3D<Q3> operator*(Q1 lhs, const Vector3D<Q2>& rhs) {
+    return rhs * lhs;
+}
 
 // define some common vector types
 typedef Vector3D<Length> V3Position;

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -21,7 +21,7 @@ template <isQuantity T> class Vector3D {
          *
          * This constructor initializes x, y, and z to 0
          */
-        Vector3D() : x(0.0), y(0.0), z(0.0) {}
+        constexpr Vector3D() : x(0.0), y(0.0), z(0.0) {}
 
         /**
          * @brief Construct a new Vector2D object
@@ -32,7 +32,7 @@ template <isQuantity T> class Vector3D {
          * @param ny y component
          * @param nz z component
          */
-        Vector3D(T nx, T ny, T nz) : x(nx), y(ny), z(nz) {}
+        constexpr Vector3D(T nx, T ny, T nz) : x(nx), y(ny), z(nz) {}
 
         /**
          * @brief Create a new Vector3D object from spherical coordinates
@@ -42,7 +42,7 @@ template <isQuantity T> class Vector3D {
          * @param t angle
          * @param m magnitude
          */
-        static Vector3D fromPolar(const Vector3D<Angle>& t, T m) {
+        constexpr static Vector3D fromPolar(const Vector3D<Angle>& t, T m) {
             m = m.abs();
             return Vector3D<T>(m * cos(t.x), m * cos(t.y), m * cos(t.z));
         }
@@ -53,7 +53,7 @@ template <isQuantity T> class Vector3D {
          * @param t angle
          * @return Vector3D
          */
-        static Vector3D unitVector(const Vector3D<Angle>& t) { return fromPolar(t, (T)1.0); }
+        constexpr static Vector3D unitVector(const Vector3D<Angle>& t) { return fromPolar(t, (T)1.0); }
 
         /**
          * @brief + operator overload
@@ -64,7 +64,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to add
          * @return Vector3D<T>
          */
-        Vector3D<T> operator+(const Vector3D<T>& other) const {
+        constexpr Vector3D<T> operator+(const Vector3D<T>& other) const {
             return Vector3D<T>(x + other.x, y + other.y, z + other.z);
         }
 
@@ -77,7 +77,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to subtract
          * @return Vector3D<T>
          */
-        Vector3D<T> operator-(const Vector3D<T>& other) const {
+        constexpr Vector3D<T> operator-(const Vector3D<T>& other) const {
             return Vector3D<T>(x - other.x, y - other.y, z - other.z);
         }
 
@@ -90,7 +90,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to multiply by
          * @return Vector3D<T>
          */
-        Vector3D<T> operator*(double factor) const { return Vector3D<T>(x * factor, y * factor, z * factor); }
+        constexpr Vector3D<T> operator*(double factor) const { return Vector3D<T>(x * factor, y * factor, z * factor); }
 
         /**
          * @brief / operator overload
@@ -101,7 +101,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to divide by
          * @return Vector3D<T>
          */
-        Vector3D<T> operator/(double factor) const { return Vector3D<T>(x / factor, y / factor, z / factor); }
+        constexpr Vector3D<T> operator/(double factor) const { return Vector3D<T>(x / factor, y / factor, z / factor); }
 
         /**
          * @brief += operator overload
@@ -112,7 +112,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to add
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator+=(const Vector3D<T>& other) {
+        constexpr Vector3D<T>& operator+=(const Vector3D<T>& other) {
             x += other.x;
             y += other.y;
             z += other.z;
@@ -128,7 +128,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to subtract
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator-=(const Vector3D<T>& other) {
+        constexpr Vector3D<T>& operator-=(const Vector3D<T>& other) {
             x -= other.x;
             y -= other.y;
             z -= other.z;
@@ -145,7 +145,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to multiply by
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator*=(double factor) {
+        constexpr Vector3D<T>& operator*=(double factor) {
             x *= factor;
             y *= factor;
             z *= factor;
@@ -162,7 +162,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to divide by
          * @return Vector3D<T>&
          */
-        Vector3D<T>& operator/=(double factor) {
+        constexpr Vector3D<T>& operator/=(double factor) {
             x /= factor;
             y /= factor;
             z /= factor;
@@ -180,7 +180,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(const Vector3D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R dot(const Vector3D<Q>& other) const {
             return (x * other.x) + (y * other.y) + (z * other.z);
         }
 
@@ -197,7 +197,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the cross product with
          * @return Vector3D<R> the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> Vector3D<R> cross(const Vector3D<Q>& other) const {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr Vector3D<R> cross(const Vector3D<Q>& other) const {
             return Vector3D<R>(y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x);
         }
 
@@ -206,7 +206,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return Angle
          */
-        Vector3D<Angle> theta() const {
+        constexpr Vector3D<Angle> theta() const {
             const T mag = magnitude();
             return Vector3D<Angle>(acos(x / mag), acos(y / mag), acos(z / mag));
         }
@@ -216,7 +216,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return T
          */
-        T magnitude() const { return sqrt(square(x) + square(y) + square(z)); }
+        constexpr T magnitude() const { return sqrt(square(x) + square(y) + square(z)); }
 
         /**
          * @brief difference between two vectors
@@ -229,7 +229,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Vector3D<T>
          */
-        Vector3D<T> vectorTo(const Vector3D<T>& other) const {
+        constexpr Vector3D<T> vectorTo(const Vector3D<T>& other) const {
             return Vector2D<T>(other.x - x, other.y - y, other.z - z);
         }
 
@@ -239,7 +239,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(const Vector3D<T>& other) const {
+        constexpr Angle angleTo(const Vector3D<T>& other) const {
             return units::acos(dot(other) / (magnitude() * other.magnitude()));
         }
 
@@ -249,7 +249,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(const Vector3D<T>& other) const { return vectorTo(other).magnitude(); }
+        constexpr T distanceTo(const Vector3D<T>& other) const { return vectorTo(other).magnitude(); }
 
         /**
          * @brief normalize the vector
@@ -258,7 +258,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return Vector3D<T>
          */
-        Vector3D<T> normalize() {
+        constexpr Vector3D<T> normalize() {
             T m = magnitude();
             return Vector2D<T>(x / m, y / m, z / m);
         }
@@ -268,7 +268,7 @@ template <isQuantity T> class Vector3D {
          *
          * @param angle
          */
-        void rotateBy(const Vector3D<Angle>& angle) {
+        constexpr void rotateBy(const Vector3D<Angle>& angle) {
             const T m = magnitude();
             const Vector3D<Angle> t = theta() + angle;
             x = m * cos(t.x);
@@ -281,7 +281,7 @@ template <isQuantity T> class Vector3D {
          *
          * @param angle
          */
-        void rotateTo(const Vector3D<Angle>& angle) {
+        constexpr void rotateTo(const Vector3D<Angle>& angle) {
             const T m = magnitude();
             x = m * cos(angle.x);
             y = m * cos(angle.y);
@@ -294,7 +294,7 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        Vector3D<T> rotatedBy(const Vector3D<Angle>& angle) const {
+        constexpr Vector3D<T> rotatedBy(const Vector3D<Angle>& angle) const {
             T m = magnitude();
             Angle t = theta() + angle;
             return fromPolar(t, m);
@@ -306,7 +306,7 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        Vector3D<T> rotatedTo(Angle angle) const {
+        constexpr Vector3D<T> rotatedTo(Angle angle) const {
             T m = magnitude();
             return fromPolar(angle, m);
         }

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -64,7 +64,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to add
          * @return Vector3D<T>
          */
-        Vector3D<T> operator+(Vector3D<T>& other) { return Vector3D<T>(x + other.x, y + other.y, z + other.z); }
+        Vector3D<T> operator+(Vector3D<T>& other) const { return Vector3D<T>(x + other.x, y + other.y, z + other.z); }
 
         /**
          * @brief - operator overload
@@ -75,7 +75,7 @@ template <isQuantity T> class Vector3D {
          * @param other vector to subtract
          * @return Vector3D<T>
          */
-        Vector3D<T> operator-(Vector3D<T>& other) { return Vector3D<T>(x - other.x, y - other.y, z - other.z); }
+        Vector3D<T> operator-(Vector3D<T>& other) const { return Vector3D<T>(x - other.x, y - other.y, z - other.z); }
 
         /**
          * @brief * operator overload
@@ -86,7 +86,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to multiply by
          * @return Vector3D<T>
          */
-        Vector3D<T> operator*(double factor) { return Vector3D<T>(x * factor, y * factor, z * factor); }
+        Vector3D<T> operator*(double factor) const { return Vector3D<T>(x * factor, y * factor, z * factor); }
 
         /**
          * @brief / operator overload
@@ -97,7 +97,7 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to divide by
          * @return Vector3D<T>
          */
-        Vector3D<T> operator/(double factor) { return Vector3D<T>(x / factor, y / factor, z / factor); }
+        Vector3D<T> operator/(double factor) const { return Vector3D<T>(x / factor, y / factor, z / factor); }
 
         /**
          * @brief += operator overload
@@ -176,7 +176,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the dot product with
          * @return R the dot product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector3D<Q>& other) {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> R dot(Vector3D<Q>& other) const {
             return (x * other.x) + (y * other.y) + (z * other.z);
         }
 
@@ -193,7 +193,7 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the cross product with
          * @return Vector3D<R> the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> Vector3D<R> cross(Vector3D<Q>& other) {
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> Vector3D<R> cross(Vector3D<Q>& other) const {
             return Vector3D<R>(y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x);
         }
 
@@ -202,7 +202,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return Angle
          */
-        Vector3D<Angle> theta() {
+        Vector3D<Angle> theta() const {
             const T mag = magnitude();
             return Vector3D<Angle>(acos(x / mag), acos(y / mag), acos(z / mag));
         }
@@ -212,7 +212,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return T
          */
-        T magnitude() { return sqrt(square(x) + square(y) + square(z)); }
+        T magnitude() const { return sqrt(square(x) + square(y) + square(z)); }
 
         /**
          * @brief difference between two vectors
@@ -225,7 +225,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Vector3D<T>
          */
-        Vector3D<T> vectorTo(Vector3D<T>& other) { return Vector2D<T>(other.x - x, other.y - y, other.z - z); }
+        Vector3D<T> vectorTo(Vector3D<T>& other) const { return Vector2D<T>(other.x - x, other.y - y, other.z - z); }
 
         /**
          * @brief the angle between two vectors
@@ -233,7 +233,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return Angle
          */
-        Angle angleTo(Vector3D<T>& other) { return units::acos(dot(other) / (magnitude() * other.magnitude())); }
+        Angle angleTo(Vector3D<T>& other) const { return units::acos(dot(other) / (magnitude() * other.magnitude())); }
 
         /**
          * @brief get the distance between two vectors
@@ -241,7 +241,7 @@ template <isQuantity T> class Vector3D {
          * @param other the other vector
          * @return T
          */
-        T distanceTo(Vector3D<T>& other) { return vectorTo(other).magnitude(); }
+        T distanceTo(Vector3D<T>& other) const { return vectorTo(other).magnitude(); }
 
         /**
          * @brief normalize the vector
@@ -286,7 +286,7 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        Vector3D<T> rotatedBy(Vector3D<Angle> angle) {
+        Vector3D<T> rotatedBy(Vector3D<Angle> angle) const {
             T m = magnitude();
             Angle t = theta() + angle;
             return fromPolar(t, m);
@@ -298,7 +298,7 @@ template <isQuantity T> class Vector3D {
          * @param angle
          * @return Vector3D<T>
          */
-        Vector3D<T> rotatedTo(Angle angle) {
+        Vector3D<T> rotatedTo(Angle angle) const {
             T m = magnitude();
             return fromPolar(angle, m);
         }

--- a/include/units/Vector3D.hpp
+++ b/include/units/Vector3D.hpp
@@ -65,7 +65,7 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> operator+(const Vector3D<T>& other) const {
-            return Vector3D<T>(x + other.x, y + other.y, z + other.z);
+            return Vector3D<T>(this->x + other.x, this->y + other.y, this->z + other.z);
         }
 
         /**
@@ -78,7 +78,7 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> operator-(const Vector3D<T>& other) const {
-            return Vector3D<T>(x - other.x, y - other.y, z - other.z);
+            return Vector3D<T>(this->x - other.x, this->y - other.y, this->z - other.z);
         }
 
         /**
@@ -90,7 +90,9 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to multiply by
          * @return Vector3D<T>
          */
-        constexpr Vector3D<T> operator*(double factor) const { return Vector3D<T>(x * factor, y * factor, z * factor); }
+        constexpr Vector3D<T> operator*(double factor) const {
+            return Vector3D<T>(this->x * factor, this->y * factor, this->z * factor);
+        }
 
         /**
          * @brief / operator overload
@@ -101,7 +103,9 @@ template <isQuantity T> class Vector3D {
          * @param factor scalar to divide by
          * @return Vector3D<T>
          */
-        constexpr Vector3D<T> operator/(double factor) const { return Vector3D<T>(x / factor, y / factor, z / factor); }
+        constexpr Vector3D<T> operator/(double factor) const {
+            return Vector3D<T>(this->x / factor, this->y / factor, this->z / factor);
+        }
 
         /**
          * @brief += operator overload
@@ -113,9 +117,9 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>&
          */
         constexpr Vector3D<T>& operator+=(const Vector3D<T>& other) {
-            x += other.x;
-            y += other.y;
-            z += other.z;
+            this->x += other.x;
+            this->y += other.y;
+            this->z += other.z;
             return (*this);
         }
 
@@ -129,9 +133,9 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>&
          */
         constexpr Vector3D<T>& operator-=(const Vector3D<T>& other) {
-            x -= other.x;
-            y -= other.y;
-            z -= other.z;
+            this->x -= other.x;
+            this->y -= other.y;
+            this->z -= other.z;
             return (*this);
         }
 
@@ -146,9 +150,9 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>&
          */
         constexpr Vector3D<T>& operator*=(double factor) {
-            x *= factor;
-            y *= factor;
-            z *= factor;
+            this->x *= factor;
+            this->y *= factor;
+            this->z *= factor;
             return (*this);
         }
 
@@ -163,9 +167,9 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>&
          */
         constexpr Vector3D<T>& operator/=(double factor) {
-            x /= factor;
-            y /= factor;
-            z /= factor;
+            this->x /= factor;
+            this->y /= factor;
+            this->z /= factor;
             return (*this);
         }
 
@@ -181,7 +185,7 @@ template <isQuantity T> class Vector3D {
          * @return R the dot product
          */
         template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr R dot(const Vector3D<Q>& other) const {
-            return (x * other.x) + (y * other.y) + (z * other.z);
+            return (this->x * other.x) + (this->y * other.y) + (this->z * other.z);
         }
 
         /**
@@ -197,8 +201,10 @@ template <isQuantity T> class Vector3D {
          * @param other the vector to calculate the cross product with
          * @return Vector3D<R> the cross product
          */
-        template <isQuantity Q, isQuantity R = Multiplied<T, Q>> constexpr Vector3D<R> cross(const Vector3D<Q>& other) const {
-            return Vector3D<R>(y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x);
+        template <isQuantity Q, isQuantity R = Multiplied<T, Q>>
+        constexpr Vector3D<R> cross(const Vector3D<Q>& other) const {
+            return Vector3D<R>(this->y * other.z - this->z * other.y, this->z * other.x - this->x * other.z,
+                               this->x * other.y - this->y * other.x);
         }
 
         /**
@@ -208,7 +214,7 @@ template <isQuantity T> class Vector3D {
          */
         constexpr Vector3D<Angle> theta() const {
             const T mag = magnitude();
-            return Vector3D<Angle>(acos(x / mag), acos(y / mag), acos(z / mag));
+            return Vector3D<Angle>(acos(this->x / mag), acos(this->y / mag), acos(this->z / mag));
         }
 
         /**
@@ -216,7 +222,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return T
          */
-        constexpr T magnitude() const { return sqrt(square(x) + square(y) + square(z)); }
+        constexpr T magnitude() const { return sqrt(square(this->x) + square(this->y) + square(this->z)); }
 
         /**
          * @brief difference between two vectors
@@ -230,7 +236,7 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> vectorTo(const Vector3D<T>& other) const {
-            return Vector2D<T>(other.x - x, other.y - y, other.z - z);
+            return Vector2D<T>(other.x - this->x, other.y - this->y, other.z - this->z);
         }
 
         /**
@@ -240,7 +246,7 @@ template <isQuantity T> class Vector3D {
          * @return Angle
          */
         constexpr Angle angleTo(const Vector3D<T>& other) const {
-            return units::acos(dot(other) / (magnitude() * other.magnitude()));
+            return acos(dot(other) / (magnitude() * other.magnitude()));
         }
 
         /**
@@ -258,10 +264,7 @@ template <isQuantity T> class Vector3D {
          *
          * @return Vector3D<T>
          */
-        constexpr Vector3D<T> normalize() {
-            T m = magnitude();
-            return Vector2D<T>(x / m, y / m, z / m);
-        }
+        constexpr Vector3D<T> normalize() { return *(this) / magnitude(); }
 
         /**
          * @brief rotate the vector by an angle
@@ -271,9 +274,9 @@ template <isQuantity T> class Vector3D {
         constexpr void rotateBy(const Vector3D<Angle>& angle) {
             const T m = magnitude();
             const Vector3D<Angle> t = theta() + angle;
-            x = m * cos(t.x);
-            y = m * cos(t.y);
-            z = m * cos(t.z);
+            this->x = m * cos(t.x);
+            this->y = m * cos(t.y);
+            this->z = m * cos(t.z);
         }
 
         /**
@@ -283,9 +286,9 @@ template <isQuantity T> class Vector3D {
          */
         constexpr void rotateTo(const Vector3D<Angle>& angle) {
             const T m = magnitude();
-            x = m * cos(angle.x);
-            y = m * cos(angle.y);
-            z = m * cos(angle.z);
+            this->x = m * cos(angle.x);
+            this->y = m * cos(angle.y);
+            this->z = m * cos(angle.z);
         }
 
         /**
@@ -295,8 +298,8 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> rotatedBy(const Vector3D<Angle>& angle) const {
-            T m = magnitude();
-            Angle t = theta() + angle;
+            const T m = magnitude();
+            const Angle t = theta() + angle;
             return fromPolar(t, m);
         }
 
@@ -307,7 +310,7 @@ template <isQuantity T> class Vector3D {
          * @return Vector3D<T>
          */
         constexpr Vector3D<T> rotatedTo(Angle angle) const {
-            T m = magnitude();
+            const T m = magnitude();
             return fromPolar(angle, m);
         }
 };

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -68,7 +68,7 @@ class Quantity {
         constexpr double internal() const { return value; }
 
         // TODO: document this
-        constexpr double convert(Self quantity) { return value / quantity.value; }
+        constexpr double convert(Self quantity) const { return value / quantity.value; }
 
         /**
          * @brief set the value of this quantity to its current value plus another quantity

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,10 +32,10 @@ void initialize() {
     Number num = Number(1.0);
     num = Number(0.0);
     a.theta().convert(deg);
-    a.setOrientation(Quantity<std::ratio<0>, std::ratio<0>, std::ratio<-2>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                              std::ratio<0>, std::ratio<0>>(1.0));
-    a.getOrientation() += 2_rpm2;
-    2_rpm2 -= a.getOrientation();
+    a.orientation = Quantity<std::ratio<0>, std::ratio<0>, std::ratio<-2>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
+                             std::ratio<0>, std::ratio<0>>(1.0);
+    a.orientation += 2_rpm2;
+    2_rpm2 -= a.orientation;
     to_cDeg(Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
                      std::ratio<0>, std::ratio<0>>(5.0) -
             a.theta() + 5_cDeg);
@@ -47,10 +47,11 @@ void initialize() {
     Length z = toLinear<Angle>(y, 2_cm);
     static_assert(Angle(5.1) >= Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
                                          std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    units::clamp(2_cDeg, a.theta(), Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                                         std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                              std::ratio<0>, std::ratio<0>>(1.0));
+    units::clamp(2_cDeg, a.theta(),
+                 Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
+                          std::ratio<0>, std::ratio<0>>(5.0));
+    units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
+                                    std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include "main.h"
 #include "units/Pose.hpp"
 #include "units/Temperature.hpp"
+#include "units/Vector2D.hpp"
+#include "units/Vector3D.hpp"
 
 /**
  * A callback function for LLEMU's center button.
@@ -52,6 +54,18 @@ void initialize() {
                           std::ratio<0>, std::ratio<0>>(5.0));
     units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
                                     std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
+    // check Vector3D overloads
+    units::Vector3D<Length> v3a = 2 * units::V3Position(2_in, 2_in, 2_in) * 2;
+    units::Vector3D<Length> v3b = units::V3Position(2_in, 2_in, 2_in) / 2.0;
+    units::Vector3D<Area> v3c = 2_in * units::V3Position(2_in, 2_in, 2_in);
+    units::Vector3D<Area> v3d = units::V3Position(2_in, 2_in, 2_in) * 2_in;
+    units::Vector3D<Number> v3e = units::V3Position(2_in, 2_in, 2_in) / 2_in;
+    // check Vector2D overloads
+    units::Vector2D<Length> v2a = units::V2Position(2_in, 2_in) / 2;
+    units::Vector2D<Length> v2b = 2 * units::V2Position(2_in, 2_in) * 2;
+    units::Vector2D<Area> v2c = 2_in * units::V2Position(2_in, 2_in);
+    units::Vector2D<Area> v2d = units::V2Position(2_in, 2_in) * 2_in;
+    units::Vector2D<Number> v2e = units::V2Position(2_in, 2_in) / 2_in;
 }
 
 /**


### PR DESCRIPTION
#### Overview
- constexpr Vector2D, Vector3D, Pose
- const Vector member functions
- vector member functions take `const Vector<T>&` as an argument
- templated `*` and `/` overloads, lhs and rhs when possible
- simplified Vector internals
- removed `vectorTo`, since it's functionality is fulfilled by the `-` operator
- made members variables public, removed setters and getters
- removed 2D cross product, it does not exist irl
- slightly modified comments to improve readability
- use `this->` when referring to member variables to improve readability

#### Motivation
These changes would make it much easier to write LemLib v0.6. So much so that I see them as a requirement for me to continue writing v0.6