### PR TITLE
✨ Convert `double` to `Number` implicitly

### DIFF
--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -101,37 +101,25 @@ static inline Angle constrainAngle180(Angle in) {
 // Standard orientation
 constexpr inline Angle from_stRad(double value) { return Angle(value); }
 
-constexpr inline Angle from_stRad(Number value) { return Angle(value.internal()); }
-
 constexpr inline double to_stRad(Angle quantity) { return quantity.internal(); }
 
 constexpr inline Angle from_stDeg(double value) { return value * deg; }
 
-constexpr inline Angle from_stDeg(Number value) { return value * deg; }
-
 constexpr inline double to_stDeg(Angle quantity) { return quantity.convert(deg); }
 
 constexpr inline Angle from_stRot(double value) { return value * rot; }
-
-constexpr inline Angle from_stRot(Number value) { return value * rot; }
 
 constexpr inline double to_stRot(Angle quantity) { return quantity.convert(rot); }
 
 // Compass orientation
 constexpr inline Angle from_cRad(double value) { return 90 * deg - Angle(value); }
 
-constexpr inline Angle from_cRad(Number value) { return 90 * deg - Angle(value.internal()); }
-
 constexpr inline double to_cRad(Angle quantity) { return quantity.internal(); }
 
 constexpr inline Angle from_cDeg(double value) { return (90 - value) * deg; }
 
-constexpr inline Angle from_cDeg(Number value) { return (90 - value.internal()) * deg; }
-
 constexpr inline double to_cDeg(Angle quantity) { return (90 * deg - quantity).convert(deg); }
 
 constexpr inline Angle from_cRot(double value) { return (90 - value) * deg; }
-
-constexpr inline Angle from_cRot(Number value) { return (90 - value.internal()) * deg; }
 
 constexpr inline double to_cRot(Angle quantity) { return (90 * deg - quantity).convert(rot); }

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -48,6 +48,8 @@ NEW_UNIT_LITERAL(AngularJerk, rpm3, rot / min / min / min)
 // Standard orientation
 constexpr Angle operator""_stRad(long double value) { return Angle(static_cast<double>(value)); }
 
+constexpr Angle operator""_stRad(unsigned long long value) { return Angle(static_cast<double>(value)); }
+
 constexpr Angle operator""_stDeg(long double value) { return static_cast<double>(value) * deg; }
 
 constexpr Angle operator""_stDeg(unsigned long long value) { return static_cast<double>(value) * deg; }

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -48,8 +48,6 @@ NEW_UNIT_LITERAL(AngularJerk, rpm3, rot / min / min / min)
 // Standard orientation
 constexpr Angle operator""_stRad(long double value) { return Angle(static_cast<double>(value)); }
 
-constexpr Angle operator""_stRad(unsigned long long value) { return Angle(static_cast<double>(value)); }
-
 constexpr Angle operator""_stDeg(long double value) { return static_cast<double>(value) * deg; }
 
 constexpr Angle operator""_stDeg(unsigned long long value) { return static_cast<double>(value) * deg; }
@@ -99,27 +97,27 @@ static inline Angle constrainAngle180(Angle in) {
 
 // Angle to/from operators
 // Standard orientation
-constexpr inline Angle from_stRad(double value) { return Angle(value); }
+constexpr inline Angle from_stRad(Number value) { return Angle(value.internal()); }
 
 constexpr inline double to_stRad(Angle quantity) { return quantity.internal(); }
 
-constexpr inline Angle from_stDeg(double value) { return value * deg; }
+constexpr inline Angle from_stDeg(Number value) { return value * deg; }
 
 constexpr inline double to_stDeg(Angle quantity) { return quantity.convert(deg); }
 
-constexpr inline Angle from_stRot(double value) { return value * rot; }
+constexpr inline Angle from_stRot(Number value) { return value * rot; }
 
 constexpr inline double to_stRot(Angle quantity) { return quantity.convert(rot); }
 
 // Compass orientation
-constexpr inline Angle from_cRad(double value) { return 90 * deg - Angle(value); }
+constexpr inline Angle from_cRad(Number value) { return 90 * deg - Angle(value.internal()); }
 
 constexpr inline double to_cRad(Angle quantity) { return quantity.internal(); }
 
-constexpr inline Angle from_cDeg(double value) { return (90 - value) * deg; }
+constexpr inline Angle from_cDeg(Number value) { return (90 - value.internal()) * deg; }
 
 constexpr inline double to_cDeg(Angle quantity) { return (90 * deg - quantity).convert(deg); }
 
-constexpr inline Angle from_cRot(double value) { return (90 - value) * deg; }
+constexpr inline Angle from_cRot(Number value) { return (90 - value.internal()) * deg; }
 
 constexpr inline double to_cRot(Angle quantity) { return (90 * deg - quantity).convert(rot); }

--- a/include/units/Temperature.hpp
+++ b/include/units/Temperature.hpp
@@ -48,15 +48,17 @@ constexpr Temperature operator""_fahrenheit(unsigned long long value) {
 
 namespace units {
 
-constexpr inline Temperature from_kelvin(double value) { return Temperature(value); }
+constexpr inline Temperature from_kelvin(Number value) { return Temperature(value.internal()); }
 
 constexpr inline double to_kelvin(Temperature quantity) { return quantity.internal(); }
 
-constexpr inline Temperature from_celsius(double value) { return Temperature(value + 273.15); }
+constexpr inline Temperature from_celsius(Number value) { return Temperature(value.internal() + 273.15); }
 
 constexpr inline double to_celsius(Temperature quantity) { return quantity.internal() - 273.15; }
 
-constexpr inline Temperature from_fahrenheit(double value) { return Temperature((value - 32) * (5.0 / 9.0) + 273.15); }
+constexpr inline Temperature from_fahrenheit(Number value) {
+    return Temperature((value.internal() - 32) * (5.0 / 9.0) + 273.15);
+}
 
 constexpr inline double to_fahrenheit(Temperature quantity) {
     return (quantity.internal() - 273.15) * (9.0 / 5.0) + 32;

--- a/include/units/Temperature.hpp
+++ b/include/units/Temperature.hpp
@@ -50,21 +50,13 @@ namespace units {
 
 constexpr inline Temperature from_kelvin(double value) { return Temperature(value); }
 
-constexpr inline Temperature from_kelvin(Number value) { return Temperature(value.internal()); }
-
 constexpr inline double to_kelvin(Temperature quantity) { return quantity.internal(); }
 
 constexpr inline Temperature from_celsius(double value) { return Temperature(value + 273.15); }
 
-constexpr inline Temperature from_celsius(Number value) { return Temperature(value.internal() + 273.15); }
-
 constexpr inline double to_celsius(Temperature quantity) { return quantity.internal() - 273.15; }
 
 constexpr inline Temperature from_fahrenheit(double value) { return Temperature((value - 32) * (5.0 / 9.0) + 273.15); }
-
-constexpr inline Temperature from_fahrenheit(Number value) {
-    return Temperature((value.internal() - 32) * (5.0 / 9.0) + 273.15);
-}
 
 constexpr inline double to_fahrenheit(Temperature quantity) {
     return (quantity.internal() - 273.15) * (9.0 / 5.0) + 32;

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -261,7 +261,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     return (lhs.internal() > rhs.internal());
 }
 
-#define NEW_UNIT(Name, suffix, m, l, t, i, a, o, j, n)                                                                 \
+#define NEW_UNIT_FULL(Name, suffix, m, l, t, i, a, o, j, n, extra)                                                     \
     class Name : public Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,            \
                                  std::ratio<o>, std::ratio<j>, std::ratio<n>> {                                        \
         public:                                                                                                        \
@@ -273,6 +273,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
                                value)                                                                                  \
                 : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
                            std::ratio<j>, std::ratio<n>>(value) {};                                                    \
+            extra                                                                                                      \
     };                                                                                                                 \
     template <> struct LookupName<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,  \
                                            std::ratio<o>, std::ratio<j>, std::ratio<n>>> {                             \
@@ -294,6 +295,8 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     constexpr inline Name from_##suffix(double value) { return Name(value); }                                          \
     constexpr inline double to_##suffix(Name quantity) { return quantity.internal(); }
 
+#define NEW_UNIT(Name, suffix, m, l, t, i, a, o, j, n) NEW_UNIT_FULL(Name, suffix, m, l, t, i, a, o, j, n, )
+
 #define NEW_UNIT_LITERAL(Name, suffix, multiple)                                                                       \
     [[maybe_unused]] constexpr Name suffix = multiple;                                                                 \
     constexpr Name operator""_##suffix(long double value) { return static_cast<double>(value) * multiple; }            \
@@ -312,7 +315,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     NEW_UNIT_LITERAL(Name, u##base, base / 1E6)                                                                        \
     NEW_UNIT_LITERAL(Name, n##base, base / 1E9)
 
-NEW_UNIT(Number, num, 0, 0, 0, 0, 0, 0, 0, 0)
+NEW_UNIT_FULL(Number, num, 0, 0, 0, 0, 0, 0, 0, 0, constexpr operator double() { return this->value; })
 NEW_UNIT_LITERAL(Number, percent, num / 100.0);
 
 NEW_UNIT(Mass, kg, 1, 0, 0, 0, 0, 0, 0, 0)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -299,7 +299,6 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     [[maybe_unused]] constexpr Name suffix = multiple;                                                                 \
     constexpr Name operator""_##suffix(long double value) { return static_cast<double>(value) * multiple; }            \
     constexpr Name operator""_##suffix(unsigned long long value) { return static_cast<double>(value) * multiple; }     \
-    constexpr inline Name from_##suffix(double value) { return value * multiple; }                                     \
     constexpr inline Name from_##suffix(Number value) { return value.internal() * multiple; }                          \
     constexpr inline double to_##suffix(Name quantity) { return quantity.convert(multiple); }
 

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -292,6 +292,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
         return os;                                                                                                     \
     }                                                                                                                  \
     constexpr inline Name from_##suffix(double value) { return Name(value); }                                          \
+    constexpr inline Name from_##suffix(Number value) { return Name(value.internal()); }                               \
     constexpr inline double to_##suffix(Name quantity) { return quantity.internal(); }
 
 #define NEW_UNIT_LITERAL(Name, suffix, multiple)                                                                       \

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -261,7 +261,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     return (lhs.internal() > rhs.internal());
 }
 
-#define NEW_UNIT_FULL(Name, suffix, m, l, t, i, a, o, j, n, extra)                                                     \
+#define NEW_UNIT(Name, suffix, m, l, t, i, a, o, j, n, ...)                                                            \
     class Name : public Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,            \
                                  std::ratio<o>, std::ratio<j>, std::ratio<n>> {                                        \
         public:                                                                                                        \
@@ -273,7 +273,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
                                value)                                                                                  \
                 : Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>, std::ratio<o>,   \
                            std::ratio<j>, std::ratio<n>>(value) {};                                                    \
-            extra                                                                                                      \
+            __VA_ARGS__                                                                                                \
     };                                                                                                                 \
     template <> struct LookupName<Quantity<std::ratio<m>, std::ratio<l>, std::ratio<t>, std::ratio<i>, std::ratio<a>,  \
                                            std::ratio<o>, std::ratio<j>, std::ratio<n>>> {                             \
@@ -295,8 +295,6 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     constexpr inline Name from_##suffix(double value) { return Name(value); }                                          \
     constexpr inline double to_##suffix(Name quantity) { return quantity.internal(); }
 
-#define NEW_UNIT(Name, suffix, m, l, t, i, a, o, j, n) NEW_UNIT_FULL(Name, suffix, m, l, t, i, a, o, j, n, )
-
 #define NEW_UNIT_LITERAL(Name, suffix, multiple)                                                                       \
     [[maybe_unused]] constexpr Name suffix = multiple;                                                                 \
     constexpr Name operator""_##suffix(long double value) { return static_cast<double>(value) * multiple; }            \
@@ -315,7 +313,7 @@ template <isQuantity Q, isQuantity R> constexpr bool operator>(const Q& lhs, con
     NEW_UNIT_LITERAL(Name, u##base, base / 1E6)                                                                        \
     NEW_UNIT_LITERAL(Name, n##base, base / 1E9)
 
-NEW_UNIT_FULL(Number, num, 0, 0, 0, 0, 0, 0, 0, 0, constexpr operator double() { return this->value; })
+NEW_UNIT(Number, num, 0, 0, 0, 0, 0, 0, 0, 0, constexpr operator double() { return this->value; })
 NEW_UNIT_LITERAL(Number, percent, num / 100.0);
 
 NEW_UNIT(Mass, kg, 1, 0, 0, 0, 0, 0, 0, 0)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -325,8 +325,6 @@ class Number : public Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std:
                              value)
             : Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
                        std::ratio<0>, std::ratio<0>>(value) {};
-
-        template <typename T> constexpr operator T() const { return T(value); }
 };
 
 template <> struct LookupName<Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
@@ -355,17 +353,7 @@ constexpr inline Number from_num(double value) { return Number(value); }
 
 constexpr inline double to_num(Number quantity) { return quantity.internal(); }
 
-[[maybe_unused]] constexpr Number percent = num / 100.0;
-
-constexpr Number operator""_percent(long double value) { return value / 100.0; }
-
-constexpr Number operator""_percent(unsigned long long value) { return value / 100.0; }
-
-constexpr inline Number from_percent(double value) { return value / 100.0; }
-
-constexpr inline Number from_percent(Number value) { return value / 100.0; }
-
-constexpr inline double to_percent(Number quantity) { return quantity.internal() * 100.0; }
+NEW_UNIT_LITERAL(Number, percent, num / 100)
 
 NEW_UNIT(Mass, kg, 1, 0, 0, 0, 0, 0, 0, 0)
 NEW_UNIT_LITERAL(Mass, g, kg / 1000)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,11 @@ void initialize() {
     Length z = toLinear<Angle>(y, 2_cm);
     static_assert(Angle(5.1) >= Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
                                          std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    units::clamp(2_cDeg, a.theta(), Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                                         std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                              std::ratio<0>, std::ratio<0>>(1.0));
+    units::clamp(2_cDeg, a.theta(),
+                 Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
+                          std::ratio<0>, std::ratio<0>>(5.0));
+    units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
+                                    std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
 }
 
 /**


### PR DESCRIPTION
#### Overview
title

#### Motivation
Consider the following:

```c++
Number num = double(2);
```

This code does not compile, even though it really should

#### Implementation

Number is defined manually instead of through macros, so the constructor is not marked `explicit`