### PR TITLE
:sparkles: unary operator overloads

### DIFF
--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -43,7 +43,9 @@ class CAngle : public Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std:
         // make CAngle able to be implicitly converted to Angle
         constexpr operator Angle() const { return Angle(M_PI_2 - this->value); }
 
-        constexpr Angle operator-() const { return Angle(M_PI_2 - this->value); }
+        constexpr CAngle operator-() const { return CAngle(-this->value); }
+
+        constexpr CAngle operator+() const { return CAngle(this->value); }
     private:
         // only allow construction through literals
         constexpr CAngle(double value)

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -51,8 +51,8 @@ class CAngle {
         friend constexpr CAngle operator""_cRot(unsigned long long value);
     public:
         // we don't want CAngle to have move, copy, or assignment operators
-        CAngle& operator=(const CAngle&) = delete;
-        CAngle(const CAngle&) = delete;
+        constexpr CAngle& operator=(const CAngle&) = delete;
+        constexpr CAngle(const CAngle&) = delete;
 
         // make CAngle able to be implicitly converted to Angle
         constexpr operator Angle() const { return Angle(M_PI_2 - this->value); }

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -50,6 +50,10 @@ class CAngle {
         friend constexpr CAngle operator""_cRot(long double value);
         friend constexpr CAngle operator""_cRot(unsigned long long value);
     public:
+        // we don't want CAngle to have move, copy, or assignment operators
+        CAngle& operator=(const CAngle&) = delete;
+        CAngle(const CAngle&) = delete;
+
         // make CAngle able to be implicitly converted to Angle
         constexpr operator Angle() const { return Angle(M_PI_2 - this->value); }
 
@@ -61,8 +65,6 @@ class CAngle {
 
         constexpr CAngle(double value) : value(value) {}
 };
-
-constexpr bool operator==(Angle lhs, CAngle rhs) { return lhs == Angle(rhs); }
 
 inline std::ostream& operator<<(std::ostream& os, const Angle& quantity) {
     os << quantity.internal() << " rad";

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -59,14 +59,16 @@ class CAngle {
         // make CAngle able to be implicitly converted to Angle
         constexpr operator Angle() const { return Angle(M_PI_2 - this->value); }
 
-        constexpr Angle operator-() const { return CAngle(-this->value); }
+        constexpr CAngle operator-() const { return CAngle(-this->value); }
 
-        constexpr Angle operator+() const { return CAngle(this->value); }
+        constexpr CAngle operator+() const { return CAngle(this->value); }
     private:
         const double value;
 
         constexpr CAngle(double value) : value(value) {}
 };
+
+constexpr bool operator==(Angle lhs, CAngle rhs) { return lhs == Angle(rhs); }
 
 constexpr Angle rad = Angle(1.0);
 constexpr Angle deg = Angle(M_PI / 180);

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -41,8 +41,7 @@ template <> struct LookupName<Quantity<std::ratio<0>, std::ratio<0>, std::ratio<
  * because the constructor is private. However, you can do
  * Angle angle = 2_cDeg
  */
-class CAngle : public Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                               std::ratio<0>, std::ratio<0>> {
+class CAngle {
         // make string literals friends, so they have access to the constructor
         friend constexpr CAngle operator""_cRad(long double value);
         friend constexpr CAngle operator""_cRad(unsigned long long value);
@@ -50,30 +49,17 @@ class CAngle : public Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std:
         friend constexpr CAngle operator""_cDeg(unsigned long long value);
         friend constexpr CAngle operator""_cRot(long double value);
         friend constexpr CAngle operator""_cRot(unsigned long long value);
-        friend constexpr CAngle operator*(double multiple, CAngle quantity);
-        friend constexpr CAngle operator*(CAngle quantity, double multiple);
-        friend constexpr CAngle operator/(double multiple, CAngle quantity);
-        friend constexpr CAngle operator/(CAngle quantity, double multiple);
     public:
         // make CAngle able to be implicitly converted to Angle
         constexpr operator Angle() const { return Angle(M_PI_2 - this->value); }
 
-        constexpr Angle operator-(Angle other) const { return Angle(*this) - other; }
+        constexpr Angle operator-() const { return CAngle(-this->value); }
 
-        constexpr CAngle operator-() const { return CAngle(-this->value); }
-
-        constexpr Angle operator+(Angle other) const { return Angle(*this) + other; }
-
-        constexpr CAngle operator+() const { return CAngle(this->value); }
+        constexpr Angle operator+() const { return CAngle(this->value); }
     private:
-        // only allow construction through literals
-        constexpr CAngle(double value)
-            : Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                       std::ratio<0>, std::ratio<0>>(value) {}
+        const double value;
 
-        constexpr CAngle(Angle value)
-            : Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                       std::ratio<0>, std::ratio<0>>(value) {}
+        constexpr CAngle(double value) : value(value) {}
 };
 
 constexpr bool operator==(Angle lhs, CAngle rhs) { return lhs == Angle(rhs); }
@@ -82,27 +68,6 @@ inline std::ostream& operator<<(std::ostream& os, const Angle& quantity) {
     os << quantity.internal() << " rad";
     return os;
 }
-
-constexpr Angle operator+(Angle lhs, CAngle rhs) { return lhs + Angle(rhs); }
-
-constexpr Angle operator-(Angle lhs, CAngle rhs) { return lhs - Angle(rhs); }
-
-constexpr CAngle operator*(double multiple, CAngle quantity) { return CAngle(multiple * quantity.internal()); }
-
-constexpr CAngle operator*(CAngle quantity, double multiple) { return CAngle(multiple * quantity.internal()); }
-
-constexpr CAngle operator/(CAngle quantity, double multiple) { return CAngle(quantity.internal() / multiple); }
-
-namespace units {
-template <typename T>
-concept isAngle = std::same_as<T, CAngle> || std::same_as<T, Angle> ||
-                  std::same_as<T, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                                           std::ratio<0>, std::ratio<0>, std::ratio<0>>>;
-
-template <isAngle Q, isAngle R, isAngle S> constexpr Angle clamp(Q lhs, R lo, S hi) {
-    return Angle(std::clamp(lhs.internal(), lo.internal(), hi.internal()));
-}
-} // namespace units
 
 constexpr Angle rad = Angle(1.0);
 constexpr Angle deg = Angle(M_PI / 180);

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -21,8 +21,10 @@ template <> struct LookupName<Quantity<std::ratio<0>, std::ratio<0>, std::ratio<
         using Named = Angle;
 };
 
-// -15_cDeg == 105_stDeg
-// 15_cDeg == 75_stDeg
+inline std::ostream& operator<<(std::ostream& os, const Angle& quantity) {
+    os << quantity.internal() << " rad";
+    return os;
+}
 
 /**
  * @brief DO NOT USE
@@ -65,11 +67,6 @@ class CAngle {
 
         constexpr CAngle(double value) : value(value) {}
 };
-
-inline std::ostream& operator<<(std::ostream& os, const Angle& quantity) {
-    os << quantity.internal() << " rad";
-    return os;
-}
 
 constexpr Angle rad = Angle(1.0);
 constexpr Angle deg = Angle(M_PI / 180);

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -37,9 +37,9 @@ template <> struct LookupName<Quantity<std::ratio<0>, std::ratio<0>, std::ratio<
  * This class solves this problem by introducing the CAngle type. You can do things like
  * negate it, multiply it, etc. without messing up the angle. However, this class can
  * only be created through string literals, you can't do something like
- * CAngle angle = 2_cDeg
+ * CAngle angle = 2_cDeg;
  * because the constructor is private. However, you can do
- * Angle angle = 2_cDeg
+ * Angle angle = 2_cDeg;
  */
 class CAngle {
         // make string literals friends, so they have access to the constructor

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -199,11 +199,15 @@ template <isQuantity Q> inline std::ostream& operator<<(std::ostream& os, const 
     return os;
 }
 
+template <isQuantity Q> constexpr Q operator+(Q rhs) { return rhs; }
+
 template <isQuantity Q, isQuantity R> constexpr Q operator+(Q lhs, R rhs)
     requires Isomorphic<Q, R>
 {
     return Q(lhs.internal() + rhs.internal());
 }
+
+template <isQuantity Q> constexpr Q operator-(Q rhs) { return Q(-rhs.internal()); }
 
 template <isQuantity Q, isQuantity R> constexpr Q operator-(Q lhs, R rhs)
     requires Isomorphic<Q, R>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,9 @@ void initialize() {
 }
 
 void angleTests() {
-    static_assert(15_cDeg == 75_stDeg);
-    static_assert(-15_cDeg == 75_stDeg);
+    static_assert(+15_cDeg == 75_stDeg);
+    static_assert(to_stDeg(-15_cDeg) == to_stDeg(105_stDeg));
     static_assert(r2i(to_stDeg(2 * 15_cDeg)) == r2i(to_stDeg(60_stDeg)));
+    static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
+    static_assert(90_stDeg == +0_cDeg);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,21 +4,7 @@
 #include "units/Vector2D.hpp"
 #include "units/Vector3D.hpp"
 
-/**
- * A callback function for LLEMU's center button.
- *
- * When this callback is fired, it will toggle line 2 of the LCD text between
- * "I was pressed!" and nothing.
- */
-void on_center_button() {
-    static bool pressed = false;
-    pressed = !pressed;
-    if (pressed) {
-        pros::lcd::set_text(2, "I was pressed!");
-    } else {
-        pros::lcd::clear_line(2);
-    }
-}
+constexpr int r2i(double value) { return static_cast<int>(value >= 0.0 ? value + 0.5 : value - 0.5); }
 
 /**
  * Runs initialization code. This occurs as soon as the program is started.
@@ -27,9 +13,6 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
-    pros::lcd::initialize();
-    pros::lcd::set_text(1, "Hello PROS User!");
-    pros::lcd::register_btn1_cb(on_center_button);
     units::AccelerationPose a(1_mps2, 2_mps2);
     Number num = Number(1.0);
     num = Number(0.0);
@@ -38,9 +21,11 @@ void initialize() {
                              std::ratio<0>, std::ratio<0>>(1.0);
     a.orientation += 2_rpm2;
     2_rpm2 -= a.orientation;
+    /*
     to_cDeg(Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
                      std::ratio<0>, std::ratio<0>>(5.0) -
             a.theta() + 5_cDeg);
+    */
     Quantity<std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>,
              std::ratio<0>>
         c = Multiplied<Angle, Time>();
@@ -49,9 +34,11 @@ void initialize() {
     Length z = toLinear<Angle>(y, 2_cm);
     static_assert(Angle(5.1) >= Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
                                          std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
+    /*
     units::clamp(2_cDeg, a.theta(),
                  Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
                           std::ratio<0>, std::ratio<0>>(5.0));
+    */
     units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
                                     std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
     // check Vector3D overloads
@@ -68,66 +55,8 @@ void initialize() {
     units::Vector2D<Number> v2e = units::V2Position(2_in, 2_in) / 2_in;
 }
 
-/**
- * Runs while the Probot is in the disabled state of Field Management System or
- * the VEX Competition Switch, following either autonomous or opcontrol. When
- * the robot is enabled, this task will exit.
- */
-void disabled() {}
-
-/**
- * Runs after initialize(), and before autonomous when connected to the Field
- * Management System or the VEX Competition Switch. This is intended for
- * competition-specific initialization routines, such as an autonomous selector
- * on the LCD.
- *
- * This task will exit when the robot is enabled and autonomous or opcontrol
- * starts.
- */
-void competition_initialize() {}
-
-/**
- * Runs the user autonomous code. This function will be started in its own task
- * with the default priority and stack size whenever the robot is enabled via
- * the Field Management System or the VEX Competition Switch in the autonomous
- * mode. Alternatively, this function may be called in initialize or opcontrol
- * for non-competition testing purposes.
- *
- * If the robot is disabled or communications is lost, the autonomous task
- * will be stopped. Re-enabling the robot will restart the task, not re-start it
- * from where it left off.
- */
-void autonomous() {}
-
-/**
- * Runs the operator control code. This function will be started in its own task
- * with the default priority and stack size whenever the robot is enabled via
- * the Field Management System or the VEX Competition Switch in the operator
- * control mode.
- *
- * If no competition control is connected, this function will run immediately
- * following initialize().
- *
- * If the robot is disabled or communications is lost, the
- * operator control task will be stopped. Re-enabling the robot will restart the
- * task, not resume it from where it left off.
- */
-void opcontrol() {
-    pros::Controller master(pros::E_CONTROLLER_MASTER);
-    pros::MotorGroup left_mg({1, -2, 3}); // Creates a motor group with forwards ports 1 & 3 and reversed port 2
-    pros::MotorGroup right_mg({-4, 5, -6}); // Creates a motor group with forwards port 4 and reversed ports 4 & 6
-
-    while (true) {
-        pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
-                         (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
-
-                         (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0); // Prints status of the emulated screen LCDs
-
-        // Arcade control scheme
-        int dir = master.get_analog(ANALOG_LEFT_Y); // Gets amount forward/backward from left joystick
-        int turn = master.get_analog(ANALOG_RIGHT_X); // Gets the turn left/right from right joystick
-        left_mg.move(dir - turn); // Sets left motor voltage
-        right_mg.move(dir + turn); // Sets right motor voltage
-        pros::delay(20); // Run for 20 ms then update
-    }
+void angleTests() {
+    static_assert(15_cDeg == 75_stDeg);
+    static_assert(-15_cDeg == 75_stDeg);
+    static_assert(r2i(to_stDeg(2 * 15_cDeg)) == r2i(to_stDeg(60_stDeg)));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,9 +21,6 @@ void initialize() {
                              std::ratio<0>, std::ratio<0>>(1.0);
     a.orientation += 2_rpm2;
     2_rpm2 -= a.orientation;
-    to_cDeg(Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                     std::ratio<0>, std::ratio<0>>(5.0) -
-            a.theta() + 5_cDeg);
     Quantity<std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>,
              std::ratio<0>>
         c = Multiplied<Angle, Time>();
@@ -32,9 +29,6 @@ void initialize() {
     Length z = toLinear<Angle>(y, 2_cm);
     static_assert(Angle(5.1) >= Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
                                          std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    units::clamp(2_cDeg, a.theta(),
-                 Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                          std::ratio<0>, std::ratio<0>>(5.0));
     units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
                                     std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
     // check Vector3D overloads
@@ -54,18 +48,7 @@ void initialize() {
 void angleTests() {
     static_assert(+15_cDeg == 75_stDeg);
     static_assert(to_stDeg(-15_cDeg) == to_stDeg(105_stDeg));
-    static_assert(r2i(to_stDeg(2 * 15_cDeg)) == r2i(to_stDeg(60_stDeg)));
+    static_assert(r2i(to_stDeg(30_cDeg)) == r2i(to_stDeg(60_stDeg)));
     static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
-    static_assert(90_stDeg == +0_cDeg);
     Angle a = 2_cDeg;
-    Angle b = 2_cDeg + 2_stDeg;
-    Angle c = 2_stDeg - 2_cDeg;
-    Angle d = 2_cDeg + Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
-                                std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0);
-    Angle e = Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                       std::ratio<0>, std::ratio<0>>(5.0) +
-              2_cDeg;
-    units::clamp(2_cDeg, 2_stDeg,
-                 Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
-                          std::ratio<0>, std::ratio<0>>(5.0));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,11 +21,9 @@ void initialize() {
                              std::ratio<0>, std::ratio<0>>(1.0);
     a.orientation += 2_rpm2;
     2_rpm2 -= a.orientation;
-    /*
     to_cDeg(Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
                      std::ratio<0>, std::ratio<0>>(5.0) -
             a.theta() + 5_cDeg);
-    */
     Quantity<std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<1>, std::ratio<0>, std::ratio<0>,
              std::ratio<0>>
         c = Multiplied<Angle, Time>();
@@ -34,11 +32,9 @@ void initialize() {
     Length z = toLinear<Angle>(y, 2_cm);
     static_assert(Angle(5.1) >= Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
                                          std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0));
-    /*
     units::clamp(2_cDeg, a.theta(),
                  Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
                           std::ratio<0>, std::ratio<0>>(5.0));
-    */
     units::max(10_celsius, Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>,
                                     std::ratio<1>, std::ratio<0>, std::ratio<0>>(1.0));
     // check Vector3D overloads
@@ -61,4 +57,15 @@ void angleTests() {
     static_assert(r2i(to_stDeg(2 * 15_cDeg)) == r2i(to_stDeg(60_stDeg)));
     static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
     static_assert(90_stDeg == +0_cDeg);
+    Angle a = 2_cDeg;
+    Angle b = 2_cDeg + 2_stDeg;
+    Angle c = 2_stDeg - 2_cDeg;
+    Angle d = 2_cDeg + Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>,
+                                std::ratio<0>, std::ratio<0>, std::ratio<0>>(5.0);
+    Angle e = Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
+                       std::ratio<0>, std::ratio<0>>(5.0) +
+              2_cDeg;
+    units::clamp(2_cDeg, 2_stDeg,
+                 Quantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>, std::ratio<0>,
+                          std::ratio<0>, std::ratio<0>>(5.0));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ void initialize() {
 
 void angleTests() {
     static_assert(+15_cDeg == 75_stDeg);
-    static_assert(to_stDeg(-15_cDeg) == to_stDeg(105_stDeg));
+    static_assert(to_stDeg(-+15_cDeg) == to_stDeg(105_stDeg));
     static_assert(r2i(to_stDeg(30_cDeg)) == r2i(to_stDeg(60_stDeg)));
     static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
     Angle a = 2_cDeg;


### PR DESCRIPTION
#### overview
- implement `+` and `-` unary operator overloads
- fix compass angle to standard position angle conversions

#### implementation
implementing `+` and `-` unary operator overloads was simple enough, but implementing a `CAngle` class was necessary to prevent strange conversions happening with the `-` unary operator:

 consider the following:
0_cDeg gets converted to standard position angles internally, so it's converted to 90.

 -0_cDeg is converted to standard position angles internally, and only afterwards is the negative applied, so now it's converted -90

while -0 = 0, 90 != -90. Now we've got a problem.

But, this was fixed with the `CAngle` class. This class can only be constructed through string literals. It's move, copy, and assignment operators are explicitly deleted, and it's constructor is private. This is all to prevent the user using the CAngle class when they should be using the `Angle` class.