### PR TITLE
✨ Number and double operators

### DIFF
--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -386,6 +386,28 @@ NEW_NUM_AND_DOUBLE_ASSIGNMENT(-)
 NEW_NUM_AND_DOUBLE_ASSIGNMENT(*)
 NEW_NUM_AND_DOUBLE_ASSIGNMENT(/)
 
+constexpr Number& operator++(Number& lhs, int) {
+    lhs += 1;
+    return lhs;
+}
+
+constexpr Number operator++(Number& lhs) {
+    Number copy = lhs;
+    lhs += 1;
+    return copy;
+}
+
+constexpr Number& operator--(Number& lhs, int) {
+    lhs -= 1;
+    return lhs;
+}
+
+constexpr Number operator--(Number& lhs) {
+    Number copy = lhs;
+    lhs -= 1;
+    return copy;
+}
+
 NEW_UNIT_LITERAL(Number, percent, num / 100)
 
 NEW_UNIT(Mass, kg, 1, 0, 0, 0, 0, 0, 0, 0)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -357,65 +357,25 @@ constexpr inline Number from_num(double value) { return Number(value); }
 
 constexpr inline double to_num(Number quantity) { return quantity.internal(); }
 
-constexpr bool operator<=(const Number& lhs, double rhs)
-{
-    return (lhs.internal() <= rhs);
-}
+#define NEW_NUM_TO_DOUBLE_COMPARISON(op)                                                                             \
+    constexpr bool operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
+    constexpr bool operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
-constexpr bool operator>=(const Number& lhs, double rhs)
-{
-    return (lhs.internal() >= rhs);
-}
+NEW_NUM_TO_DOUBLE_COMPARISON(==)
+NEW_NUM_TO_DOUBLE_COMPARISON(!=)
+NEW_NUM_TO_DOUBLE_COMPARISON(<=)
+NEW_NUM_TO_DOUBLE_COMPARISON(>=)
+NEW_NUM_TO_DOUBLE_COMPARISON(<)
+NEW_NUM_TO_DOUBLE_COMPARISON(>)
 
-constexpr bool operator<(const Number& lhs, double rhs)
-{
-    return (lhs.internal() < rhs);
-}
+#define NEW_NUM_AND_DOUBLE_OPERATION(op)                                                                             \
+    constexpr Number operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
+    constexpr Number operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
-constexpr bool operator>(const Number& lhs, double rhs)
-{
-    return (lhs.internal() > rhs);
-}
-
-constexpr bool operator==(const Number& lhs, double rhs)
-{
-    return (lhs.internal() == rhs);
-}
-
-constexpr bool operator!=(const Number& lhs, double rhs)
-{
-    return (lhs.internal() != rhs);
-}
-
-constexpr bool operator<=(double lhs, const Number& rhs)
-{
-    return (lhs <= rhs.internal());
-}
-
-constexpr bool operator>=(double lhs, const Number& rhs)
-{
-    return (lhs >= rhs.internal());
-}
-
-constexpr bool operator<(double lhs, const Number& rhs)
-{
-    return (lhs < rhs.internal());
-}
-
-constexpr bool operator>(double lhs, const Number& rhs)
-{
-    return (lhs > rhs.internal());
-}
-
-constexpr bool operator==(double lhs, const Number& rhs)
-{
-    return (lhs == rhs.internal());
-}
-
-constexpr bool operator!=(double lhs, const Number& rhs)
-{
-    return (lhs != rhs.internal());
-}
+NEW_NUM_AND_DOUBLE_OPERATION(+)
+NEW_NUM_AND_DOUBLE_OPERATION(-)
+NEW_NUM_AND_DOUBLE_OPERATION(*)
+NEW_NUM_AND_DOUBLE_OPERATION(/)
 
 NEW_UNIT_LITERAL(Number, percent, num / 100)
 

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -357,6 +357,56 @@ constexpr inline Number from_num(double value) { return Number(value); }
 
 constexpr inline double to_num(Number quantity) { return quantity.internal(); }
 
+constexpr bool operator<=(const Number& lhs, double rhs)
+{
+    return (lhs.internal() <= rhs);
+}
+
+constexpr bool operator>=(const Number& lhs, double rhs)
+{
+    return (lhs.internal() >= rhs);
+}
+
+constexpr bool operator<(const Number& lhs, double rhs)
+{
+    return (lhs.internal() < rhs);
+}
+
+constexpr bool operator>(const Number& lhs, double rhs)
+{
+    return (lhs.internal() > rhs);
+}
+
+constexpr bool operator==(const Number& lhs, double rhs)
+{
+    return (lhs.internal() == rhs);
+}
+
+constexpr bool operator<=(double lhs, const Number& rhs)
+{
+    return (lhs <= rhs.internal());
+}
+
+constexpr bool operator>=(double lhs, const Number& rhs)
+{
+    return (lhs >= rhs.internal());
+}
+
+constexpr bool operator<(double lhs, const Number& rhs)
+{
+    return (lhs < rhs.internal());
+}
+
+constexpr bool operator>(double lhs, const Number& rhs)
+{
+    return (lhs > rhs.internal());
+}
+
+constexpr bool operator==(double lhs, const Number& rhs)
+{
+    return (lhs == rhs.internal());
+}
+
 NEW_UNIT_LITERAL(Number, percent, num / 100)
 
 NEW_UNIT(Mass, kg, 1, 0, 0, 0, 0, 0, 0, 0)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -132,7 +132,7 @@ concept isQuantity = requires(Q q) { quantityChecker(q); };
 
 // Isomorphic concept - used to ensure unit equivalecy
 template <typename Q, typename... Quantities>
-concept Isomorphic = ((std::convertible_to<Q, Quantities> && std::convertible_to<Quantities, Q>) && ...);
+concept Isomorphic = ((std::convertible_to<Q, Quantities> && std::convertible_to<Quantities, Q>)&&...);
 
 // Un(type)safely coerce the a unit into a different unit
 template <isQuantity Q1, isQuantity Q2> constexpr inline Q1 unit_cast(Q2 quantity) { return Q1(quantity.internal()); }
@@ -357,8 +357,8 @@ constexpr inline Number from_num(double value) { return Number(value); }
 
 constexpr inline double to_num(Number quantity) { return quantity.internal(); }
 
-#define NEW_NUM_TO_DOUBLE_COMPARISON(op)                                                                             \
-    constexpr bool operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
+#define NEW_NUM_TO_DOUBLE_COMPARISON(op)                                                                               \
+    constexpr bool operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                             \
     constexpr bool operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
 NEW_NUM_TO_DOUBLE_COMPARISON(==)
@@ -368,8 +368,8 @@ NEW_NUM_TO_DOUBLE_COMPARISON(>=)
 NEW_NUM_TO_DOUBLE_COMPARISON(<)
 NEW_NUM_TO_DOUBLE_COMPARISON(>)
 
-#define NEW_NUM_AND_DOUBLE_OPERATION(op)                                                                             \
-    constexpr Number operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
+#define NEW_NUM_AND_DOUBLE_OPERATION(op)                                                                               \
+    constexpr Number operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                           \
     constexpr Number operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
 NEW_NUM_AND_DOUBLE_OPERATION(+)
@@ -377,8 +377,8 @@ NEW_NUM_AND_DOUBLE_OPERATION(-)
 NEW_NUM_AND_DOUBLE_OPERATION(*)
 NEW_NUM_AND_DOUBLE_OPERATION(/)
 
-#define NEW_NUM_AND_DOUBLE_ASSIGNMENT(op)                                                                             \
-    constexpr void operator op##=(Number& lhs, double rhs) { lhs = lhs.internal() op rhs; }            \
+#define NEW_NUM_AND_DOUBLE_ASSIGNMENT(op)                                                                              \
+    constexpr void operator op##=(Number& lhs, double rhs) { lhs = lhs.internal() op rhs; }                            \
     constexpr void operator op##=(double& lhs, Number rhs) { lhs = lhs op rhs.internal(); }
 
 NEW_NUM_AND_DOUBLE_ASSIGNMENT(+)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -130,9 +130,9 @@ void quantityChecker(Quantity<Mass, Length, Time, Current, Angle, Temperature, L
 template <typename Q>
 concept isQuantity = requires(Q q) { quantityChecker(q); };
 
-// Isomorphic concept - used to ensure unit equivalecy
+// Isomorphic concept - used to ensure unit equivalency
 template <typename Q, typename... Quantities>
-concept Isomorphic = ((std::convertible_to<Q, Quantities> && std::convertible_to<Quantities, Q>)&&...);
+concept Isomorphic = ((std::convertible_to<Q, Quantities> && std::convertible_to<Quantities, Q>) && ...);
 
 // Un(type)safely coerce the a unit into a different unit
 template <isQuantity Q1, isQuantity Q2> constexpr inline Q1 unit_cast(Q2 quantity) { return Q1(quantity.internal()); }

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -372,10 +372,19 @@ NEW_NUM_TO_DOUBLE_COMPARISON(>)
     constexpr Number operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
     constexpr Number operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
+#define NEW_NUM_AND_DOUBLE_ASSIGNMENT(op)                                                                             \
+    constexpr void operator op##=(Number& lhs, double rhs) { lhs = lhs.internal() op rhs; }            \
+    constexpr void operator op##=(double& lhs, Number rhs) { lhs = lhs op rhs.internal(); }
+
 NEW_NUM_AND_DOUBLE_OPERATION(+)
 NEW_NUM_AND_DOUBLE_OPERATION(-)
 NEW_NUM_AND_DOUBLE_OPERATION(*)
 NEW_NUM_AND_DOUBLE_OPERATION(/)
+
+NEW_NUM_AND_DOUBLE_ASSIGNMENT(+)
+NEW_NUM_AND_DOUBLE_ASSIGNMENT(-)
+NEW_NUM_AND_DOUBLE_ASSIGNMENT(*)
+NEW_NUM_AND_DOUBLE_ASSIGNMENT(/)
 
 NEW_UNIT_LITERAL(Number, percent, num / 100)
 

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -372,14 +372,14 @@ NEW_NUM_TO_DOUBLE_COMPARISON(>)
     constexpr Number operator op(Number lhs, double rhs) { return (lhs.internal() op rhs); }                     \
     constexpr Number operator op(double lhs, Number rhs) { return (lhs op rhs.internal()); }
 
-#define NEW_NUM_AND_DOUBLE_ASSIGNMENT(op)                                                                             \
-    constexpr void operator op##=(Number& lhs, double rhs) { lhs = lhs.internal() op rhs; }            \
-    constexpr void operator op##=(double& lhs, Number rhs) { lhs = lhs op rhs.internal(); }
-
 NEW_NUM_AND_DOUBLE_OPERATION(+)
 NEW_NUM_AND_DOUBLE_OPERATION(-)
 NEW_NUM_AND_DOUBLE_OPERATION(*)
 NEW_NUM_AND_DOUBLE_OPERATION(/)
+
+#define NEW_NUM_AND_DOUBLE_ASSIGNMENT(op)                                                                             \
+    constexpr void operator op##=(Number& lhs, double rhs) { lhs = lhs.internal() op rhs; }            \
+    constexpr void operator op##=(double& lhs, Number rhs) { lhs = lhs op rhs.internal(); }
 
 NEW_NUM_AND_DOUBLE_ASSIGNMENT(+)
 NEW_NUM_AND_DOUBLE_ASSIGNMENT(-)

--- a/include/units/units.hpp
+++ b/include/units/units.hpp
@@ -382,6 +382,11 @@ constexpr bool operator==(const Number& lhs, double rhs)
     return (lhs.internal() == rhs);
 }
 
+constexpr bool operator!=(const Number& lhs, double rhs)
+{
+    return (lhs.internal() != rhs);
+}
+
 constexpr bool operator<=(double lhs, const Number& rhs)
 {
     return (lhs <= rhs.internal());
@@ -405,6 +410,11 @@ constexpr bool operator>(double lhs, const Number& rhs)
 constexpr bool operator==(double lhs, const Number& rhs)
 {
     return (lhs == rhs.internal());
+}
+
+constexpr bool operator!=(double lhs, const Number& rhs)
+{
+    return (lhs != rhs.internal());
 }
 
 NEW_UNIT_LITERAL(Number, percent, num / 100)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,14 +53,30 @@ void angleTests() {
     Angle a = 2_cDeg;
 }
 
+constexpr Number numAssignmentTests() {
+    Number n = 1_num; // 1
+    n += 2; // 3
+    n -= 2; // 1
+    n *= 2; // 2
+    n /= 2; // 1
+    return n;
+}
+
+constexpr double doubleAssignmentTests() {
+    double d = 1; // 1
+    d += 2_num; // 3
+    d -= 2_num; // 1
+    d *= 2_num; // 2
+    d /= 2_num; // 1
+    return d;
+}
+
+
 void numberOperatorTests() {
     static_assert(1_num + 2 == 3);
     static_assert(1 + 2_num <= 3);
     static_assert(1 / 2_num >= 0);
 
-    Number n = 1_num;
-    n += 2;
-
-    double d = 1;
-    d *= 2_num;
+    static_assert(numAssignmentTests() == 1);
+    static_assert(doubleAssignmentTests() == 1);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,32 +53,14 @@ void angleTests() {
     Angle a = 2_cDeg;
 }
 
-void numberComparisonTests() {
-    // ==
-    static_assert(1_num == 1);
-    static_assert(1 == 1_num);
+void numberOperatorTests() {
+    static_assert(1_num + 2 == 3);
+    static_assert(1 + 2_num <= 3);
+    static_assert(1 / 2_num >= 0);
 
-    // !=
-    static_assert(1_num != 2);
-    static_assert(2 != 1_num);
+    Number n = 1_num;
+    n += 2;
 
-    // <
-    static_assert(1_num < 2);
-    static_assert(0 < 1_num);
-
-    // <=
-    static_assert(1_num <= 2);
-    static_assert(1_num <= 1);
-    static_assert(0 <= 1_num);
-    static_assert(1 <= 1_num);
-
-    // >
-    static_assert(2_num > 1);
-    static_assert(2 > 1_num);
-    
-    // >=
-    static_assert(1_num >= 0);
-    static_assert(1_num >= 1);
-    static_assert(2 >= 1_num);
-    static_assert(1 >= 1_num);
+    double d = 1;
+    d *= 2_num;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,3 +52,33 @@ void angleTests() {
     static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
     Angle a = 2_cDeg;
 }
+
+void numberComparisonTests() {
+    // ==
+    static_assert(1_num == 1);
+    static_assert(1 == 1_num);
+
+    // !=
+    static_assert(1_num != 2);
+    static_assert(2 != 1_num);
+
+    // <
+    static_assert(1_num < 2);
+    static_assert(0 < 1_num);
+
+    // <=
+    static_assert(1_num <= 2);
+    static_assert(1_num <= 1);
+    static_assert(0 <= 1_num);
+    static_assert(1 <= 1_num);
+
+    // >
+    static_assert(2_num > 1);
+    static_assert(2 > 1_num);
+    
+    // >=
+    static_assert(1_num >= 0);
+    static_assert(1_num >= 1);
+    static_assert(2 >= 1_num);
+    static_assert(1 >= 1_num);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,11 @@ void angleTests() {
 constexpr Number numAssignmentTests() {
     Number n = 1_num; // 1
     n += 2; // 3
-    n -= 2; // 1
-    n *= 2; // 2
-    n /= 2; // 1
+    n--; // 2
+    n -= 3; // -1
+    n *= 2; // -2
+    n /= 2; // -1
+    n++; // 0
     return n;
 }
 
@@ -77,6 +79,6 @@ void numberOperatorTests() {
     static_assert(1 + 2_num <= 3);
     static_assert(1 / 2_num >= 0);
 
-    static_assert(numAssignmentTests() == 1);
+    static_assert(numAssignmentTests() == 0);
     static_assert(doubleAssignmentTests() == 1);
 }


### PR DESCRIPTION
#### Summary
Adds comparisons, operators, and assignments to combinations of `Number`s and doubles

#### Motivation
Makes working with `Number`s more seamless, being able to compare them and use operators with doubles (e.g. `1_num < 2` or `3_num * 1`).

#### Test Plan
All static_asserts in `numberOperatorTests()` found in `./src/main.cpp` passed, the assignment operators cannot be `constexpr`ed and will be tested on hardware.

#### Additional Notes
Doubles cannot be initialized with a number (e.g. `double d = 1_num` fails).