### PR TITLE
✨ AngleRange class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ IS_LIBRARY:=1
 # Be sure that your header files are in the include directory inside of a folder with the
 # same name as what you set LIBNAME to below.
 LIBNAME:=units
-VERSION:=0.4.1
+VERSION:=0.4.2
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -82,13 +82,13 @@ class CAngle {
  * implicitly. So, yet another helper class is necessary (hooray)
  *
  */
-class AngleDistance : public Angle {
+class AngleRange : public Angle {
     public:
-        explicit constexpr AngleDistance(double value) : Angle(fabs(value)) {}
+        explicit constexpr AngleRange(double value) : Angle(fabs(value)) {}
 
-        constexpr AngleDistance(Angle value) : Angle(units::abs(value)) {}
+        constexpr AngleRange(Angle value) : Angle(units::abs(value)) {}
 
-        constexpr AngleDistance(CAngle value) : Angle(units::abs(Angle(value) - Angle(M_PI_2))) {}
+        constexpr AngleRange(CAngle value) : Angle(units::abs(Angle(value) - Angle(M_PI_2))) {}
 };
 
 constexpr bool operator==(Angle lhs, CAngle rhs) { return lhs == Angle(rhs); }

--- a/include/units/Angle.hpp
+++ b/include/units/Angle.hpp
@@ -68,6 +68,29 @@ class CAngle {
         constexpr CAngle(double value) : value(value) {}
 };
 
+/**
+ * @brief Angle Distance class
+ *
+ * yet another helper class to manage the compass angle fiasco (it's getting nuked on May 15 2025)
+ *
+ * consider the following:
+ * Angle exitRange1 = 0_cDeg;
+ * Angle exitRange2 = 0_stDeg;
+ *
+ * It is expected that exitRange1 and exitRange2 is equal to each other.
+ * However, this is not the case. 0_cDeg gets converted to 90_stDeg
+ * implicitly. So, yet another helper class is necessary (hooray)
+ *
+ */
+class AngleDistance : public Angle {
+    public:
+        explicit constexpr AngleDistance(double value) : Angle(fabs(value)) {}
+
+        constexpr AngleDistance(Angle value) : Angle(units::abs(value)) {}
+
+        constexpr AngleDistance(CAngle value) : Angle(units::abs(Angle(value) - Angle(M_PI_2))) {}
+};
+
 constexpr bool operator==(Angle lhs, CAngle rhs) { return lhs == Angle(rhs); }
 
 constexpr Angle rad = Angle(1.0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,11 +53,11 @@ constexpr void angleTests() {
     Angle a = 2_cDeg;
 }
 
-constexpr void angleDistanceTests() {
-    static_assert(r2i(to_stDeg(AngleDistance(-15_cDeg))) == r2i(to_stDeg(AngleDistance(+15_stDeg))));
-    Angle a = 2_stDeg + AngleDistance(15_stDeg);
-    Angle b = AngleDistance(15_stDeg) + 2_stDeg;
-    Angle c = 2_stDeg + AngleDistance(15_cDeg);
+constexpr void angleRangeTests() {
+    static_assert(r2i(to_stDeg(AngleRange(-15_cDeg))) == r2i(to_stDeg(AngleRange(+15_stDeg))));
+    Angle a = 2_stDeg + AngleRange(15_stDeg);
+    Angle b = AngleRange(15_stDeg) + 2_stDeg;
+    Angle c = 2_stDeg + AngleRange(15_cDeg);
 }
 
 constexpr Number numAssignmentTests() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,12 +45,19 @@ void initialize() {
     units::Vector2D<Number> v2e = units::V2Position(2_in, 2_in) / 2_in;
 }
 
-void angleTests() {
+constexpr void angleTests() {
     static_assert(+15_cDeg == 75_stDeg);
     static_assert(to_stDeg(-+15_cDeg) == to_stDeg(105_stDeg));
     static_assert(r2i(to_stDeg(30_cDeg)) == r2i(to_stDeg(60_stDeg)));
     static_assert(r2i(to_stDeg(+0_cDeg)) == r2i(to_stDeg(90_stDeg)));
     Angle a = 2_cDeg;
+}
+
+constexpr void angleDistanceTests() {
+    // static_assert(r2i(to_stDeg(AngleDistance(-15_cDeg))) == r2i(to_stDeg(AngleDistance(+15_stDeg))));
+    Angle a = 2_stDeg + AngleDistance(15_stDeg);
+    Angle b = AngleDistance(15_stDeg) + 2_stDeg;
+    Angle c = 2_stDeg + AngleDistance(15_cDeg);
 }
 
 constexpr Number numAssignmentTests() {
@@ -72,7 +79,6 @@ constexpr double doubleAssignmentTests() {
     d /= 2_num; // 1
     return d;
 }
-
 
 void numberOperatorTests() {
     static_assert(1_num + 2 == 3);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ constexpr void angleTests() {
 }
 
 constexpr void angleDistanceTests() {
-    // static_assert(r2i(to_stDeg(AngleDistance(-15_cDeg))) == r2i(to_stDeg(AngleDistance(+15_stDeg))));
+    static_assert(r2i(to_stDeg(AngleDistance(-15_cDeg))) == r2i(to_stDeg(AngleDistance(+15_stDeg))));
     Angle a = 2_stDeg + AngleDistance(15_stDeg);
     Angle b = AngleDistance(15_stDeg) + 2_stDeg;
     Angle c = 2_stDeg + AngleDistance(15_cDeg);


### PR DESCRIPTION
#### Overview
Adds the AngleRange class

#### Motivation
Consider the following:
```c++
Angle exitRange1 = 0_stDeg;
Angle exitRange2 = 0_cDeg;
```
in this example, `exitRange1` is converted to 0 stDeg internally, while `exitRange2` is converted to 90 stDeg internally. The 2 are not equal. To fix this, we need yet another helper class: `AngleRange`
```c++
AngleRange exitRange1 = 0_stDeg;
AngleRange exitRange2 = 0_cDeg;
```

#### Implementation
AngleRange inherits from the `Angle` class, so it works fine in Angle expressions (e.g `AngleRange(0_stDeg) + 0_stDeg`).
It can be constructed implicitly with both `Angle` and `CAngle`, with different behavior for each.